### PR TITLE
fix: connection bulk add remove logic

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/ConnectionService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/ConnectionService.java
@@ -11,6 +11,7 @@ import static uk.nhs.hee.tis.revalidation.connection.entity.GmcResponseCode.from
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -135,10 +136,11 @@ public class ConnectionService {
           connectionRequestType);
       return handleGmcResponse(doctor.getGmcId(), changeReason, designatedBodyCode,
           doctor.getCurrentDesignatedBodyCode(), gmcResponse, connectionRequestType);
-    }).filter(response -> !response.getMessage().equals(SUCCESS.getMessage()))
-        .findAny();
-    if (addRemoveResponse.isPresent()) {
-      final var errorMessage = getReturnMessage(addRemoveResponse.get().getMessage(),
+    }).collect(Collectors.toList());
+    final var addRemoveResponseFiltered = addRemoveResponse.stream()
+        .filter(response -> !response.getMessage().equals(SUCCESS.getMessage())).findAny();
+    if (addRemoveResponseFiltered.isPresent()) {
+      final var errorMessage = getReturnMessage(addRemoveResponseFiltered.get().getMessage(),
           addDoctorDto.getDoctors().size());
       return UpdateConnectionResponseDto.builder().message(errorMessage).build();
     }

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/ConnectionServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/ConnectionServiceTest.java
@@ -176,7 +176,7 @@ class ConnectionServiceTest {
     connectionService.removeDoctor(removeDoctorDto);
     var message = ConnectionMessage.builder().gmcId(gmcId).designatedBodyCode(designatedBodyCode)
         .build();
-    verify(exceptionService).createExceptionLog(gmcId, returnCode);
+    verify(exceptionService, times(2)).createExceptionLog(gmcId, returnCode);
   }
 
   @Test


### PR DESCRIPTION
Connection bulk add remove logic was not working accordingly due to the condition in the stream map iteration.
Fix was done by separating the condition from the the stream.

The unit test is fixed

TIS21-1130