### PR TITLE
fix: elasticsearch date formatting error

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/ConnectionInfoDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/ConnectionInfoDto.java
@@ -1,10 +1,15 @@
 package uk.nhs.hee.tis.revalidation.connection.dto;
 
 import java.time.LocalDate;
+
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Data
 public class ConnectionInfoDto {
 

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/ExceptionSummaryDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/ExceptionSummaryDto.java
@@ -3,7 +3,6 @@ package uk.nhs.hee.tis.revalidation.connection.dto;
 import java.util.List;
 import lombok.Builder;
 import lombok.Data;
-import uk.nhs.hee.tis.revalidation.connection.entity.ExceptionView;
 
 @Data
 @Builder
@@ -12,5 +11,5 @@ public class ExceptionSummaryDto {
   private long countTotal;
   private long totalPages;
   private long totalResults;
-  private List<ExceptionView> connections;
+  private List<ConnectionInfoDto> connections;
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/entity/ExceptionView.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/entity/ExceptionView.java
@@ -1,11 +1,15 @@
 package uk.nhs.hee.tis.revalidation.connection.entity;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
 
 import java.time.LocalDate;
 
@@ -19,11 +23,19 @@ public class ExceptionView {
   private String gmcReferenceNumber;
   private String doctorFirstName;
   private String doctorLastName;
+  @Field(type = FieldType.Date, format = DateFormat.custom, pattern = "uuuu-MM-dd")
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern ="yyyy-MM-dd")
   private LocalDate submissionDate;
   private String programmeName;
-  private String programmeMembershipType;
+  private String membershipType;
   private String designatedBody;
   private String tcsDesignatedBody;
   private String programmeOwner;
   private String connectionStatus;
+  @Field(type = FieldType.Date, format = DateFormat.custom, pattern = "uuuu-MM-dd")
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern ="yyyy-MM-dd")
+  private LocalDate membershipStartDate;
+  @Field(type = FieldType.Date, format = DateFormat.custom, pattern = "uuuu-MM-dd")
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern ="yyyy-MM-dd")
+  private LocalDate membershipEndDate;
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/mapper/ConnectionInfoMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/mapper/ConnectionInfoMapper.java
@@ -1,0 +1,20 @@
+package uk.nhs.hee.tis.revalidation.connection.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import uk.nhs.hee.tis.revalidation.connection.dto.ConnectionInfoDto;
+import uk.nhs.hee.tis.revalidation.connection.entity.ExceptionView;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface ConnectionInfoMapper {
+
+  @Mapping(target = "programmeMembershipType", source = "membershipType")
+  @Mapping(target = "programmeMembershipStartDate", source = "membershipStartDate")
+  @Mapping(target = "programmeMembershipEndDate", source = "membershipEndDate")
+  @Mapping(target = "dataSource", ignore=true)
+  ConnectionInfoDto toDto(ExceptionView userType);
+
+  List<ConnectionInfoDto> toDtos(List<ExceptionView> userTypes);
+}

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/ElasticSearchIndexUpdateHelper.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/ElasticSearchIndexUpdateHelper.java
@@ -47,11 +47,13 @@ public class ElasticSearchIndexUpdateHelper {
             .doctorLastName(connectionInfo.getDoctorLastName())
             .submissionDate(connectionInfo.getSubmissionDate())
             .programmeName(connectionInfo.getProgrammeName())
-            .programmeMembershipType(connectionInfo.getProgrammeMembershipType())
+            .membershipType(connectionInfo.getProgrammeMembershipType())
             .designatedBody(connectionInfo.getDesignatedBody())
             .tcsDesignatedBody(connectionInfo.getTcsDesignatedBody())
             .programmeOwner(connectionInfo.getProgrammeOwner())
             .connectionStatus(getConnectionStatus(connectionInfo.getDesignatedBody()))
+            .membershipStartDate(connectionInfo.getProgrammeMembershipStartDate())
+            .membershipEndDate(connectionInfo.getProgrammeMembershipEndDate())
             .build()
     );
     return exceptions;

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/ExceptionElasticSearchService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/ExceptionElasticSearchService.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.revalidation.connection.dto.ExceptionSummaryDto;
 import uk.nhs.hee.tis.revalidation.connection.entity.ExceptionView;
+import uk.nhs.hee.tis.revalidation.connection.mapper.ConnectionInfoMapper;
 import uk.nhs.hee.tis.revalidation.connection.repository.ExceptionElasticSearchRepository;
 
 @Service
@@ -22,6 +23,9 @@ public class ExceptionElasticSearchService {
 
   @Autowired
   ExceptionElasticSearchRepository exceptionElasticSearchRepository;
+
+  @Autowired
+  ConnectionInfoMapper connectionInfoMapper;
 
 
   /**
@@ -51,7 +55,7 @@ public class ExceptionElasticSearchService {
       return ExceptionSummaryDto.builder()
           .totalPages(result.getTotalPages())
           .totalResults(result.getTotalElements())
-          .connections(exceptions)
+          .connections(connectionInfoMapper.toDtos(exceptions))
           .build();
 
     } catch (RuntimeException re) {

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionControllerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionControllerTest.java
@@ -29,12 +29,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import uk.nhs.hee.tis.revalidation.connection.dto.ConnectionDto;
-import uk.nhs.hee.tis.revalidation.connection.dto.ConnectionHistoryDto;
-import uk.nhs.hee.tis.revalidation.connection.dto.DoctorInfoDto;
-import uk.nhs.hee.tis.revalidation.connection.dto.ExceptionSummaryDto;
-import uk.nhs.hee.tis.revalidation.connection.dto.UpdateConnectionDto;
-import uk.nhs.hee.tis.revalidation.connection.dto.UpdateConnectionResponseDto;
+import uk.nhs.hee.tis.revalidation.connection.dto.*;
 import uk.nhs.hee.tis.revalidation.connection.entity.ConnectionRequestType;
 import uk.nhs.hee.tis.revalidation.connection.entity.ExceptionView;
 import uk.nhs.hee.tis.revalidation.connection.service.ConnectionService;
@@ -288,8 +283,8 @@ class ConnectionControllerTest {
         .build();
   }
 
-  private List<ExceptionView> buildDoctorsForDBList() {
-    final var doctor1 = ExceptionView.builder()
+  private List<ConnectionInfoDto> buildDoctorsForDBList() {
+    final var doctor1 = ConnectionInfoDto.builder()
         .gmcReferenceNumber(gmcRef1)
         .doctorFirstName(firstName1)
         .doctorLastName(lastName1)
@@ -299,7 +294,7 @@ class ConnectionControllerTest {
         .programmeOwner(programmeOwner1)
         .build();
 
-    final var doctor2 = ExceptionView.builder()
+    final var doctor2 = ConnectionInfoDto.builder()
         .gmcReferenceNumber(gmcRef2)
         .doctorFirstName(firstName2)
         .doctorLastName(lastName2)

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/ElasticSearchIndexUpdateHelperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/ElasticSearchIndexUpdateHelperTest.java
@@ -31,6 +31,8 @@ public class ElasticSearchIndexUpdateHelperTest {
       .designatedBody("body")
       .tcsDesignatedBody("tcsbody")
       .programmeOwner("owner")
+      .programmeMembershipStartDate(LocalDate.now().minusDays(100))
+      .programmeMembershipEndDate(LocalDate.now().plusDays(100))
       .dataSource("source")
       .build();
 
@@ -44,6 +46,8 @@ public class ElasticSearchIndexUpdateHelperTest {
       .designatedBody(null)
       .tcsDesignatedBody("tcsbody")
       .programmeOwner("owner")
+      .programmeMembershipStartDate(LocalDate.now().minusDays(100))
+      .programmeMembershipEndDate(LocalDate.now().plusDays(100))
       .dataSource("source")
       .build();
 
@@ -58,6 +62,8 @@ public class ElasticSearchIndexUpdateHelperTest {
       .tcsDesignatedBody("tcsbody")
       .programmeOwner("owner")
       .connectionStatus("status")
+      .programmeMembershipStartDate(LocalDate.now().minusDays(100))
+      .programmeMembershipEndDate(LocalDate.now().plusDays(100))
       .dataSource("source")
       .build();
 
@@ -94,11 +100,15 @@ public class ElasticSearchIndexUpdateHelperTest {
     assert (returnedView.getDoctorLastName()).equals(visitorExceptionDto.getDoctorLastName());
     assert (returnedView.getSubmissionDate()).equals(visitorExceptionDto.getSubmissionDate());
     assert (returnedView.getProgrammeName()).equals(visitorExceptionDto.getProgrammeName());
-    assert (returnedView.getProgrammeMembershipType())
+    assert (returnedView.getMembershipType())
         .equals(visitorExceptionDto.getProgrammeMembershipType());
     assert (returnedView.getDesignatedBody()).equals(visitorExceptionDto.getDesignatedBody());
     assert (returnedView.getTcsDesignatedBody()).equals(visitorExceptionDto.getTcsDesignatedBody());
     assert (returnedView.getProgrammeOwner()).equals(visitorExceptionDto.getProgrammeOwner());
+    assert (returnedView.getMembershipStartDate())
+        .equals(visitorExceptionDto.getProgrammeMembershipStartDate());
+    assert (returnedView.getMembershipEndDate())
+        .equals(visitorExceptionDto.getProgrammeMembershipEndDate());
     assert (returnedView.getConnectionStatus()).equals(CONNECTED);
   }
 

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/ElasticSearchServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/ElasticSearchServiceTest.java
@@ -39,7 +39,7 @@ public class ElasticSearchServiceTest {
         .doctorLastName("last")
         .submissionDate(LocalDate.now())
         .programmeName("programme")
-        .programmeMembershipType(SUBSTANTIVE)
+        .membershipType(SUBSTANTIVE)
         .designatedBody("body")
         .tcsDesignatedBody("tcsbody")
         .programmeOwner("owner")

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/ExceptionElasticSearchServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/ExceptionElasticSearchServiceTest.java
@@ -1,0 +1,71 @@
+package uk.nhs.hee.tis.revalidation.connection.service;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import uk.nhs.hee.tis.revalidation.connection.dto.ExceptionSummaryDto;
+import uk.nhs.hee.tis.revalidation.connection.entity.ExceptionView;
+import uk.nhs.hee.tis.revalidation.connection.mapper.ConnectionInfoMapper;
+import uk.nhs.hee.tis.revalidation.connection.repository.ExceptionElasticSearchRepository;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ExceptionElasticSearchServiceTest {
+
+  @Mock
+  ExceptionElasticSearchRepository exceptionElasticSearchRepository;
+
+  @Mock
+  ConnectionInfoMapper connectionInfoMapper;
+
+  @InjectMocks
+  ExceptionElasticSearchService exceptionElasticSearchService;
+
+  private Page<ExceptionView> searchResult;
+  private List<ExceptionView> exceptionViews = new ArrayList<>();
+
+  private static final String GMCID = "123";
+  private static final String SUBSTANTIVE = "Substantive";
+  private static final String TEST_QUERY =
+      "sortColumn=gmcReferenceNumber&sortOrder=asc&pageNumber=0&filter=exceptionsQueue&dbcs=1-AIIDWA,1-AIIDVS,1-AIIDWI,1-AIIDR8,1-AIIDMY,1-AIIDSA,1-AIIDWT";
+
+  @BeforeEach
+  public void setup() {
+    ExceptionView exceptionView = ExceptionView.builder()
+        .gmcReferenceNumber(GMCID)
+        .doctorFirstName("first")
+        .doctorLastName("last")
+        .submissionDate(LocalDate.now())
+        .programmeName("programme")
+        .membershipType(SUBSTANTIVE)
+        .designatedBody("body")
+        .tcsDesignatedBody("tcsbody")
+        .programmeOwner("owner")
+        .connectionStatus("Yes")
+        .build();
+    exceptionViews.add(exceptionView);
+    searchResult = new PageImpl<>(exceptionViews);
+
+  }
+
+  @Test
+  void shouldUseElasticSearchRepository() {
+    doReturn(searchResult).when(exceptionElasticSearchRepository).search(any(QueryBuilder.class), any(Pageable.class));
+    exceptionElasticSearchService.searchForPage(TEST_QUERY, Pageable.unpaged());
+    verify(exceptionElasticSearchRepository).search(any(QueryBuilder.class), any(Pageable.class));
+  }
+}


### PR DESCRIPTION
Spring ElasticSearch stores dates as Long by default - this fix helps us use it with LocalDate
Also reintroduced programme start and end dates