### PR TITLE
fix: stop removing from ES by gmcNumber when gmcNumber is null

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/ElasticSearchIndexUpdateHelper.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/ElasticSearchIndexUpdateHelper.java
@@ -29,7 +29,9 @@ public class ElasticSearchIndexUpdateHelper {
       elasticSearchService.addExceptionViews(getExceptionViews(connectionInfo));
     }
     else {
-      elasticSearchService.removeExceptionView(connectionInfo.getGmcReferenceNumber());
+      if (connectionInfo.getGmcReferenceNumber() != null) {
+        elasticSearchService.removeExceptionView(connectionInfo.getGmcReferenceNumber());
+      }
     }
   }
 

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/ExceptionElasticSearchService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/ExceptionElasticSearchService.java
@@ -47,7 +47,7 @@ public class ExceptionElasticSearchService {
       // add the free text query with a must to the column filters query
       BoolQueryBuilder fullQuery = mustBetweenDifferentColumnFilters.must(shouldQuery);
 
-//      LOG.info("Query {}", fullQuery);
+      LOG.debug("Query {}", fullQuery);
 
       Page<ExceptionView> result = exceptionElasticSearchRepository.search(fullQuery, pageable);
 

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/ExceptionElasticSearchService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/ExceptionElasticSearchService.java
@@ -47,7 +47,7 @@ public class ExceptionElasticSearchService {
       // add the free text query with a must to the column filters query
       BoolQueryBuilder fullQuery = mustBetweenDifferentColumnFilters.must(shouldQuery);
 
-      LOG.info("Query {}", fullQuery);
+//      LOG.info("Query {}", fullQuery);
 
       Page<ExceptionView> result = exceptionElasticSearchRepository.search(fullQuery, pageable);
 

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/ElasticSearchIndexUpdateHelperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/ElasticSearchIndexUpdateHelperTest.java
@@ -1,5 +1,6 @@
 package uk.nhs.hee.tis.revalidation.connection.service;
 
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
@@ -78,6 +79,16 @@ public class ElasticSearchIndexUpdateHelperTest {
     elasticSearchIndexUpdateHelper.updateElasticSearchIndex(visitorExceptionDto);
     verify(elasticSearchService).addExceptionViews(
         elasticSearchIndexUpdateHelper.getExceptionViews(visitorExceptionDto)
+    );
+  }
+
+  @Test
+  void shouldNotRemoveExceptionIfGmcReferenceNumberNull() {
+    ConnectionInfoDto noGmcExceptionDto = noExceptionDto;
+    noGmcExceptionDto.setGmcReferenceNumber(null);
+    elasticSearchIndexUpdateHelper.updateElasticSearchIndex(noGmcExceptionDto);
+    verify(elasticSearchService, never()).removeExceptionView(
+        noGmcExceptionDto.getGmcReferenceNumber()
     );
   }
 


### PR DESCRIPTION
and remove full query log

<NO-TICKET>