### PR TITLE
fix: ignore unknown fields for sync purposes

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/ConnectionInfoDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/ConnectionInfoDto.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.tis.revalidation.connection.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,6 +32,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ConnectionInfoDto {
 
   Long tcsPersonId;


### PR DESCRIPTION
ConnectionInfoDto from TIS (source of truth) contains fields for handling sync behaviour not required by connections (consumer)