### PR TITLE
chore: added logging level to avoid noise in cloud watch

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,3 +47,8 @@ app:
 sentry:
   dsn: ${SENTRY_DSN:}
   environment: ${SENTRY_ENVIRONMENT:}
+
+logging:
+  level:
+    org.springframework.*: ERROR
+    uk.nhs.hee.tis.revalidation.connection: INFO


### PR DESCRIPTION
This config will restrict some logs which is getting populated in the cloud watch and occupying space.