### PR TITLE
fix: remove DBC check on manual connection update

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/ConnectionService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/ConnectionService.java
@@ -179,18 +179,10 @@ public class ConnectionService {
     final var changeReason = addDoctorDto.getChangeReason();
     final var designatedBodyCode = addDoctorDto.getDesignatedBodyCode();
     final var addRemoveResponse = addDoctorDto.getDoctors().stream().map(doctor -> {
-      if (doctor.getCurrentDesignatedBodyCode()
-          .equals(doctor.getProgrammeOwnerDesignatedBodyCode())) {
-        final var gmcResponse = delegateRequest(changeReason, designatedBodyCode, doctor,
-            connectionRequestType);
-        return handleGmcResponse(doctor.getGmcId(), changeReason, designatedBodyCode,
-            doctor.getCurrentDesignatedBodyCode(), gmcResponse, connectionRequestType);
-      } else {
-        String errorMessage = "Doctor's current designated body "
-            + "does not match with current programme owner";
-        exceptionService.createExceptionLog(doctor.getGmcId(), errorMessage);
-        return UpdateConnectionResponseDto.builder().message(errorMessage).build();
-      }
+      final var gmcResponse = delegateRequest(changeReason, designatedBodyCode, doctor,
+          connectionRequestType);
+      return handleGmcResponse(doctor.getGmcId(), changeReason, designatedBodyCode,
+          doctor.getCurrentDesignatedBodyCode(), gmcResponse, connectionRequestType);
     }).collect(Collectors.toList());
     final var addRemoveResponseFiltered = addRemoveResponse.stream()
         .filter(response -> !response.getMessage().equals(SUCCESS.getMessage())).findAny();

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/ConnectionServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/ConnectionServiceTest.java
@@ -257,23 +257,6 @@ class ConnectionServiceTest {
     assertThat(hiddenGmcIds.size(), is(0));
   }
 
-  @Test
-  void shouldAddToExceptionQueueIfTraineeCurrentDbcAndProgrammeOwnerDbcDoesNotMatch()
-      throws Exception {
-    final var updateConnectionDto = UpdateConnectionDto.builder()
-        .changeReason(changeReason)
-        .designatedBodyCode(designatedBodyCode)
-        .doctors(Arrays.asList(DoctorInfoDto.builder().gmcId(gmcId)
-            .currentDesignatedBodyCode(designatedBodyCode)
-            .programmeOwnerDesignatedBodyCode(programmeOwnerDesignatedBodyCode)
-            .build()))
-        .build();
-    connectionService.addDoctor(updateConnectionDto);
-    String errorMessage = "Doctor's current designated body "
-        + "does not match with current programme owner";
-    verify(exceptionService).createExceptionLog(gmcId, errorMessage);
-  }
-
   private ConnectionRequestLog prepareConnectionAdd() {
     return ConnectionRequestLog.builder()
         .id(connectionId)


### PR DESCRIPTION
Add/remove doctor GMC request, already have a check on DBC, that means if the DBC is not valid, it will return an error, and the trainee will go to the exception queue. So don't necessarily need a duplicate check in the code on our side.

The existing thing in our code of DBC check is over-limiting to the actions. For example if a user have added a wrong connection to a trainee by mistake, then he want to remove and correct it. But due to the DMC mismatch, both add and remove action are blocked and he can no longer do any update on this trainee again.

This checking will be limited in this PR.