### PR TITLE
fix: remove .keyword suffix from gmcReferenceNumberSort following fie…

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionController.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionController.java
@@ -66,7 +66,6 @@ public class ConnectionController {
   private static final String DESIGNATED_BODY_CODES = "dbcs";
   private static final String SEARCH_QUERY = "searchQuery";
   private static final String EMPTY_STRING = "";
-  private static final String KEYWORD = ".keyword";
 
   @Autowired
   private ConnectionService connectionService;
@@ -220,7 +219,7 @@ public class ConnectionController {
       String searchQuery) throws ConnectionQueryException {
     final var direction = "asc".equalsIgnoreCase(sortOrder) ? ASC : DESC;
     final var pageableAndSortable = of(pageNumber, 20,
-        by(direction, sortColumn.concat(KEYWORD)));
+        by(direction, sortColumn));
 
     searchQuery = getConverter(searchQuery).fromJson().decodeUrl().escapeForSql().toString();
     var searchQueryES = getConverter(searchQuery).fromJson().decodeUrl().escapeForElasticSearch()
@@ -256,7 +255,7 @@ public class ConnectionController {
       String searchQuery) {
     final var direction = "asc".equalsIgnoreCase(sortOrder) ? ASC : DESC;
     final var pageableAndSortable = of(pageNumber, 20,
-        by(direction, sortColumn.concat(KEYWORD)));
+        by(direction, sortColumn));
 
     searchQuery = getConverter(searchQuery).fromJson().decodeUrl().escapeForSql().toString();
     var searchQueryES = getConverter(searchQuery).fromJson().decodeUrl().escapeForElasticSearch()
@@ -291,7 +290,7 @@ public class ConnectionController {
       String searchQuery) {
     final var direction = "asc".equalsIgnoreCase(sortOrder) ? ASC : DESC;
     final var pageableAndSortable = of(pageNumber, 20,
-        by(direction, sortColumn.concat(KEYWORD)));
+        by(direction, sortColumn));
 
     searchQuery = getConverter(searchQuery).fromJson().decodeUrl().escapeForSql().toString();
     var searchQueryES = getConverter(searchQuery).fromJson().decodeUrl().escapeForElasticSearch()

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionControllerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionControllerTest.java
@@ -259,7 +259,7 @@ class ConnectionControllerTest {
   void shouldReturnExceptionTraineeDoctorsInformation() throws Exception {
     final var connectionSummary = prepareConnectionSummary();
     final var pageableAndSortable = PageRequest.of(Integer.parseInt(PAGE_NUMBER_VALUE), 20,
-        by(ASC, "gmcReferenceNumber.keyword"));
+        by(ASC, "gmcReferenceNumber"));
     when(discrepanciesElasticSearchService.searchForPage(EMPTY_STRING, pageableAndSortable))
         .thenReturn(connectionSummary);
     final var dbcString = String.format("%s,%s", designatedBody1, designatedBody2);
@@ -292,7 +292,7 @@ class ConnectionControllerTest {
   void shouldReturnExceptionTraineeDoctorsInformationDesc() throws Exception {
     final var connectionSummary = prepareConnectionSummary();
     final var pageableAndSortable = PageRequest.of(Integer.parseInt(PAGE_NUMBER_VALUE), 20,
-        by(DESC, "gmcReferenceNumber.keyword"));
+        by(DESC, "gmcReferenceNumber"));
     when(discrepanciesElasticSearchService.searchForPage(EMPTY_STRING, pageableAndSortable))
         .thenReturn(connectionSummary);
     final var dbcString = String.format("%s,%s", designatedBody1, designatedBody2);
@@ -311,7 +311,7 @@ class ConnectionControllerTest {
   void shouldReturnConnectedTraineeDoctorsInformation() throws Exception {
     final var connectionSummary = prepareConnectionSummary();
     final var pageableAndSortable = PageRequest.of(Integer.parseInt(PAGE_NUMBER_VALUE), 20,
-        by(ASC, "gmcReferenceNumber.keyword"));
+        by(ASC, "gmcReferenceNumber"));
     when(connectedElasticSearchService.searchForPage(EMPTY_STRING,
         List.of(designatedBody1, designatedBody2), pageableAndSortable))
         .thenReturn(connectionSummary);
@@ -343,7 +343,7 @@ class ConnectionControllerTest {
   void shouldReturnConnectedTraineeDoctorsInformationDesc() throws Exception {
     final var connectionSummary = prepareConnectionSummary();
     final var pageableAndSortable = PageRequest.of(Integer.parseInt(PAGE_NUMBER_VALUE), 20,
-        by(DESC, "gmcReferenceNumber.keyword"));
+        by(DESC, "gmcReferenceNumber"));
     when(connectedElasticSearchService.searchForPage(EMPTY_STRING,
         List.of(designatedBody1, designatedBody2), pageableAndSortable))
         .thenReturn(connectionSummary);
@@ -362,7 +362,7 @@ class ConnectionControllerTest {
   void shouldReturnDisconnectedTraineeDoctorsInformation() throws Exception {
     final var connectionSummary = prepareConnectionSummary();
     final var pageableAndSortable = PageRequest.of(Integer.parseInt(PAGE_NUMBER_VALUE), 20,
-        by(ASC, "gmcReferenceNumber.keyword"));
+        by(ASC, "gmcReferenceNumber"));
     when(disconnectedElasticSearchService.searchForPage(EMPTY_STRING, pageableAndSortable))
         .thenReturn(connectionSummary);
     final var dbcString = String.format("%s,%s", designatedBody1, designatedBody2);
@@ -393,7 +393,7 @@ class ConnectionControllerTest {
   void shouldReturnDisconnectedTraineeDoctorsInformationDesc() throws Exception {
     final var connectionSummary = prepareConnectionSummary();
     final var pageableAndSortable = PageRequest.of(Integer.parseInt(PAGE_NUMBER_VALUE), 20,
-        by(DESC, "gmcReferenceNumber.keyword"));
+        by(DESC, "gmcReferenceNumber"));
     when(disconnectedElasticSearchService.searchForPage(EMPTY_STRING, pageableAndSortable))
         .thenReturn(connectionSummary);
     final var dbcString = String.format("%s,%s", designatedBody1, designatedBody2);

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/ConnectedElasticSearchServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/ConnectedElasticSearchServiceTest.java
@@ -106,7 +106,7 @@ class ConnectedElasticSearchServiceTest {
   @Test
   void shouldSearchForPage() {
     final var pageableAndSortable = PageRequest.of(Integer.parseInt(PAGE_NUMBER_VALUE), 20,
-        by(ASC, "gmcReferenceNumber.keyword"));
+        by(ASC, "gmcReferenceNumber"));
     final List<String> dbcs = List.of(designatedBody1, designatedBody2);
     final String formattedDbcs = "1rsspz7 1rssq1b";
 
@@ -129,7 +129,7 @@ class ConnectedElasticSearchServiceTest {
   void shouldSearchForPageWithQuery() {
     String searchQuery = gmcRef1;
     final var pageableAndSortable = PageRequest.of(Integer.parseInt(PAGE_NUMBER_VALUE), 20,
-        by(ASC, "gmcReferenceNumber.keyword"));
+        by(ASC, "gmcReferenceNumber"));
     final List<String> dbcs = List.of(designatedBody1, designatedBody2);
     final String formattedDbcs = "1rsspz7 1rssq1b";
 
@@ -153,7 +153,7 @@ class ConnectedElasticSearchServiceTest {
   void shouldThrowRuntimeExceptionWhenSearchForPageWithQuery() {
     String searchQuery = gmcRef1;
     final var pageableAndSortable = PageRequest.of(Integer.parseInt(PAGE_NUMBER_VALUE), 20,
-        by(ASC, "gmcReferenceNumber.keyword"));
+        by(ASC, "gmcReferenceNumber"));
     final List<String> dbcs = List.of(designatedBody1, designatedBody2);
     final String formattedDbcs = "1rsspz7 1rssq1b";
 

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/DisconnectedElasticSearchServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/DisconnectedElasticSearchServiceTest.java
@@ -109,7 +109,7 @@ class DisconnectedElasticSearchServiceTest {
     BoolQueryBuilder shouldQuery = new BoolQueryBuilder();
     BoolQueryBuilder fullQuery = mustBetweenDifferentColumnFilters.must(shouldQuery);
     final var pageableAndSortable = PageRequest.of(Integer.parseInt(PAGE_NUMBER_VALUE), 20,
-        by(ASC, "gmcReferenceNumber.keyword"));
+        by(ASC, "gmcReferenceNumber"));
 
     when(disconnectedElasticSearchRepository.search(fullQuery, pageableAndSortable))
         .thenReturn(searchResult);
@@ -139,7 +139,7 @@ class DisconnectedElasticSearchServiceTest {
     BoolQueryBuilder mustBetweenDifferentColumnFilters = new BoolQueryBuilder();
     BoolQueryBuilder fullQuery = mustBetweenDifferentColumnFilters.must(shouldQuery);
     final var pageableAndSortable = PageRequest.of(Integer.parseInt(PAGE_NUMBER_VALUE), 20,
-        by(ASC, "gmcReferenceNumber.keyword"));
+        by(ASC, "gmcReferenceNumber"));
 
     when(disconnectedElasticSearchRepository.search(fullQuery, pageableAndSortable))
         .thenReturn(searchResult);

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/DiscrepanciesElasticSearchServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/DiscrepanciesElasticSearchServiceTest.java
@@ -104,7 +104,7 @@ class DiscrepanciesElasticSearchServiceTest {
   @Test
   void shouldSearchForPage() throws ConnectionQueryException {
     final var pageableAndSortable = PageRequest.of(Integer.parseInt(PAGE_NUMBER_VALUE), 20,
-        by(ASC, "gmcReferenceNumber.keyword"));
+        by(ASC, "gmcReferenceNumber"));
 
     when(discrepanciesElasticSearchRepository.findAll("", pageableAndSortable))
         .thenReturn(searchResult);
@@ -125,7 +125,7 @@ class DiscrepanciesElasticSearchServiceTest {
   void shouldThrowRuntimeExceptionWhenSearchForPage() {
     String searchQuery = gmcRef1;
     final var pageableAndSortable = PageRequest.of(Integer.parseInt(PAGE_NUMBER_VALUE), 20,
-        by(ASC, "gmcReferenceNumber.keyword"));
+        by(ASC, "gmcReferenceNumber"));
 
     when(discrepanciesElasticSearchRepository.findAll(searchQuery,
         pageableAndSortable))


### PR DESCRIPTION
…ld metadata change in ES

TIS21-4554: Should ignore case when searching for doctors in Connections summary