### PR TITLE
fix: use lower case search queries

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionController.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionController.java
@@ -259,7 +259,7 @@ public class ConnectionController {
 
     searchQuery = getConverter(searchQuery).fromJson().decodeUrl().escapeForSql().toString();
     var searchQueryES = getConverter(searchQuery).fromJson().decodeUrl().escapeForElasticSearch()
-        .toString();
+        .toString().toLowerCase();
     var connectionSummaryDto = connectedElasticSearchService
         .searchForPage(searchQueryES, dbcs, pageableAndSortable);
 
@@ -294,7 +294,7 @@ public class ConnectionController {
 
     searchQuery = getConverter(searchQuery).fromJson().decodeUrl().escapeForSql().toString();
     var searchQueryES = getConverter(searchQuery).fromJson().decodeUrl().escapeForElasticSearch()
-        .toString();
+        .toString().toLowerCase();
     var connectionSummaryDto = disconnectedElasticSearchService
         .searchForPage(searchQueryES, pageableAndSortable);
 


### PR DESCRIPTION
TIS21-4554: Should ignore case when searching for doctors in Connections summary