### PR TITLE
fix: remove unused config

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/config/RabbitConfig.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/config/RabbitConfig.java
@@ -23,84 +23,15 @@ package uk.nhs.hee.tis.revalidation.connection.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.amqp.core.AcknowledgeMode;
-import org.springframework.amqp.core.Binding;
-import org.springframework.amqp.core.BindingBuilder;
-import org.springframework.amqp.core.DirectExchange;
-import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class RabbitConfig {
-
-  @Value("${app.rabbit.reval.exchange.gmcsync}")
-  private String gmcSyncExchange;
-
-  @Value("${app.rabbit.reval.queue.connection.manualupdate}")
-  private String queueName;
-
-  @Value("${app.rabbit.reval.routingKey.connection.manualupdate}")
-  private String routingKey;
-
-  @Value("${app.rabbit.reval.exchange}")
-  private String esExchange;
-
-  @Value("${app.rabbit.reval.queue.connection.update}")
-  private String esTisQueueName;
-
-  @Value("${app.rabbit.reval.routingKey.connection.update}")
-  private String esTisRoutingKey;
-
-  @Value("${app.rabbit.reval.queue.gmcsync.connection}")
-  private String gmcSyncQueueName;
-
-  @Value("${app.rabbit.reval.routingKey.gmcsync}")
-  private String gmcSyncRoutingKey;
-
-  @Bean
-  public Queue queue() {
-    return new Queue(queueName, false);
-  }
-
-  @Bean
-  public Queue esTisQueue() {
-    return new Queue(esTisQueueName, false);
-  }
-
-  @Bean
-  public Queue gmcSyncQueue() {
-    return new Queue(gmcSyncQueueName, false);
-  }
-
-  @Bean
-  public DirectExchange gmcSyncExchange() {
-    return new DirectExchange(gmcSyncExchange);
-  }
-
-  @Bean
-  public DirectExchange esExchange() {
-    return new DirectExchange(esExchange);
-  }
-
-  @Bean
-  public Binding binding(final Queue queue, final DirectExchange esExchange) {
-    return BindingBuilder.bind(queue).to(esExchange).with(routingKey);
-  }
-
-  @Bean
-  public Binding esTisBinding(final Queue esTisQueue, final DirectExchange esExchange) {
-    return BindingBuilder.bind(esTisQueue).to(esExchange).with(esTisRoutingKey);
-  }
-
-  @Bean
-  public Binding esGmcBinding(final Queue gmcSyncQueue, final DirectExchange gmcSyncExchange) {
-    return BindingBuilder.bind(gmcSyncQueue).to(gmcSyncExchange).with(gmcSyncRoutingKey);
-  }
 
   @Bean
   public MessageConverter jsonMessageConverter() {
@@ -109,9 +40,10 @@ public class RabbitConfig {
   }
 
   @Bean
-  public RabbitTemplate rabbitTemplate(final ConnectionFactory connectionFactory) {
+  public RabbitTemplate rabbitTemplate(final ConnectionFactory connectionFactory,
+      MessageConverter jsonMessageConverter) {
     final var rabbitTemplate = new RabbitTemplate(connectionFactory);
-    rabbitTemplate.setMessageConverter(jsonMessageConverter());
+    rabbitTemplate.setMessageConverter(jsonMessageConverter);
     rabbitTemplate.containerAckMode(AcknowledgeMode.AUTO);
     return rabbitTemplate;
   }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/ConnectionService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/ConnectionService.java
@@ -36,7 +36,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.revalidation.connection.dto.ConnectionDto;
@@ -61,29 +60,34 @@ import uk.nhs.hee.tis.revalidation.connection.repository.HideConnectionRepositor
 @Service
 public class ConnectionService {
 
-  @Autowired
-  private GmcClientService gmcClientService;
+  private final GmcClientService gmcClientService;
 
-  @Autowired
-  private ExceptionService exceptionService;
+  private final ExceptionService exceptionService;
 
-  @Autowired
-  private ConnectionRepository repository;
+  private final ConnectionRepository repository;
 
-  @Autowired
-  private HideConnectionRepository hideRepository;
+  private final HideConnectionRepository hideRepository;
 
-  @Autowired
-  private DoctorsForDBRepository doctorsForDbRepository;
+  private final DoctorsForDBRepository doctorsForDbRepository;
 
-  @Autowired
-  private RabbitTemplate rabbitTemplate;
+  private final RabbitTemplate rabbitTemplate;
 
   @Value("${app.rabbit.reval.exchange}")
   private String exchange;
 
   @Value("${app.rabbit.reval.routingKey.connection.manualupdate}")
   private String routingKey;
+
+  public ConnectionService(GmcClientService gmcClientService, ExceptionService exceptionService,
+      ConnectionRepository repository, HideConnectionRepository hideRepository,
+      DoctorsForDBRepository doctorsForDbRepository, RabbitTemplate rabbitTemplate) {
+    this.gmcClientService = gmcClientService;
+    this.exceptionService = exceptionService;
+    this.repository = repository;
+    this.hideRepository = hideRepository;
+    this.doctorsForDbRepository = doctorsForDbRepository;
+    this.rabbitTemplate = rabbitTemplate;
+  }
 
   public UpdateConnectionResponseDto addDoctor(final UpdateConnectionDto addDoctorDto) {
     return processConnectionRequest(addDoctorDto, ADD);
@@ -187,7 +191,7 @@ public class ConnectionService {
   private GmcConnectionResponseDto delegateRequest(final String changeReason,
       final String designatedBodyCode,
       final DoctorInfoDto doctor, final ConnectionRequestType connectionRequestType) {
-    GmcConnectionResponseDto gmcResponse = null;
+    GmcConnectionResponseDto gmcResponse;
     if (ADD == connectionRequestType) {
       gmcResponse = gmcClientService
           .tryAddDoctor(doctor.getGmcId(), changeReason, designatedBodyCode);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,14 +30,8 @@ app:
     limit.retries: true
 
   rabbit:
-    reval.exchange.gmcsync: ${EXCHANGE:reval.exchange.gmcsync}
-    reval.queue.gmcsync.connection: ${REVAL_RABBIT_GMCSYNC_CONNECTION_QUEUE:reval.queue.gmcsync.connection}
     reval.routingKey.gmcsync: ${REVAL_RABBIT_GMCSYNC_ROUTING_KEY:reval.gmcsync}
     reval.exchange: ${REVAL_RABBIT_EXCHANGE:reval.exchange}
-    reval.queue.connection.update: ${REVAL_RABBIT_QUEUE:reval.queue.connection.update}
-    reval.routingKey.connection.update: ${REVAL_RABBIT_ROUTING_KEY:reval.connection.update}
-    reval.queue.connection.manualupdate: ${CONNECTION_QUEUE:reval.queue.connection.manualupdate.recommendation}
-    reval.queue.masterdoctorview.updated.connection: ${REVAL_RABBIT_INDEX_CHANGE_QUEUE:reval.queue.masterdoctorview.updated.connection}
     reval.routingKey.connection.manualupdate: ${CONNECTION_ROUTING_KEY:reval.connection.manualupdate}
 
   gmc:

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/ConnectionServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/ConnectionServiceTest.java
@@ -130,7 +130,7 @@ class ConnectionServiceTest {
 
     programmeOwnerDesignatedBodyCode = faker.number().digits(8);
 
-    setField(connectionService, "esExchange", "esExchange");
+    setField(connectionService, "exchange", "esExchange");
     setField(connectionService, "routingKey", "routingKey");
   }
 


### PR DESCRIPTION
Config issues can cause silent startup issues.
It can also re-introduce legacy configuration on startup. Yes, this should have been cleared up already.

chore: use single object mapper

Calling the java method `jsonMessageConverter()` creates a new instance. There is no apparent need for the creation of 2 separate beans.

chore(smells): cleaning up sonar flagged issue

This might lead to more!

TIS21-5261: GMC Sync stalled