### PR TITLE
Feat/hide discrepancies tis21 8285

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.revalidation"
-version = "0.4.1"
+version = "0.5.0"
 sourceCompatibility = "11"
 
 configurations {
@@ -37,6 +37,7 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-web-services"
   implementation "org.springframework.boot:spring-boot-starter-data-mongodb"
   implementation "org.springframework.boot:spring-boot-starter-amqp"
+  implementation "org.springframework.boot:spring-boot-starter-validation"
   implementation group: "org.springframework.boot", name: "spring-boot-starter-data-elasticsearch"
 
   testImplementation("org.springframework.boot:spring-boot-starter-test") {

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionController.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionController.java
@@ -83,20 +83,32 @@ public class ConnectionController {
   private static final String CONNECTION_LAST_UPDATED_DATE_TO = "lastConnectionDateTimeTo";
   private static final String UPDATED_BY = "updatedBy";
 
-  @Autowired
   private ConnectionService connectionService;
-
-  @Autowired
   private DiscrepanciesElasticSearchService discrepanciesElasticSearchService;
-
-  @Autowired
   private ConnectedElasticSearchService connectedElasticSearchService;
-
-  @Autowired
   private DisconnectedElasticSearchService disconnectedElasticSearchService;
-
-  @Autowired
   private HiddenDiscrepancyService hiddenDiscrepancyService;
+
+  /**
+   * Constructs a new ConnectionController with the specified services.
+   *
+   * @param connectionService                 the service for managing connections
+   * @param discrepanciesElasticSearchService the service for retrieving doctor discrepancies
+   * @param connectedElasticSearchService     the service for retrieving connected doctors
+   * @param disconnectedElasticSearchService  the service for retrieving disconnected doctors
+   * @param hiddenDiscrepancyService          the service for managing hidden discrepancies
+   */
+  public ConnectionController(ConnectionService connectionService,
+      DiscrepanciesElasticSearchService discrepanciesElasticSearchService,
+      ConnectedElasticSearchService connectedElasticSearchService,
+      DisconnectedElasticSearchService disconnectedElasticSearchService,
+      HiddenDiscrepancyService hiddenDiscrepancyService) {
+    this.connectionService = connectionService;
+    this.discrepanciesElasticSearchService = discrepanciesElasticSearchService;
+    this.connectedElasticSearchService = connectedElasticSearchService;
+    this.disconnectedElasticSearchService = disconnectedElasticSearchService;
+    this.hiddenDiscrepancyService = hiddenDiscrepancyService;
+  }
 
   /**
    * POST  /connections/add : Add a new connection.
@@ -284,7 +296,7 @@ public class ConnectionController {
             lastConnectionDateTimeTo,
             updatedBy,
             pageableAndSortable
-          );
+        );
 
     return ResponseEntity.ok(connectionSummaryDto);
   }
@@ -354,7 +366,7 @@ public class ConnectionController {
             lastConnectionDateTimeTo,
             updatedBy,
             pageableAndSortable
-          );
+        );
 
     return ResponseEntity.ok(connectionSummaryDto);
   }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionController.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionController.java
@@ -34,6 +34,7 @@ import io.swagger.annotations.ApiResponses;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
+import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -48,6 +49,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.nhs.hee.tis.revalidation.connection.dto.ConnectionDto;
 import uk.nhs.hee.tis.revalidation.connection.dto.ConnectionSummaryDto;
 import uk.nhs.hee.tis.revalidation.connection.dto.HideDiscrepancyDto;
+import uk.nhs.hee.tis.revalidation.connection.dto.HideDiscrepancyResponseDto;
 import uk.nhs.hee.tis.revalidation.connection.dto.UpdateConnectionDto;
 import uk.nhs.hee.tis.revalidation.connection.dto.UpdateConnectionResponseDto;
 import uk.nhs.hee.tis.revalidation.connection.exception.ConnectionQueryException;
@@ -392,10 +394,19 @@ public class ConnectionController {
     return ResponseEntity.ok(connectionSummaryDto);
   }
 
+  /**
+   * POST  /discrepancies/hidden : Hide discrepancies for a list of GMC IDs.
+   *
+   * @param hideDiscrepancyDto the details of discrepancies to hide
+   * @return the ResponseEntity with status 200 (OK) and details of hidden discrepancies in body
+   */
   @PostMapping("/discrepancies/hidden")
-  public void hideDiscrepancies(@RequestBody final HideDiscrepancyDto hideDiscrepancyDto) {
-    log.info("Request received to hide discrepancies: {}", hideDiscrepancyDto.getDoctorGmcIds());
-    // todo: validate if the admin user has permission to hide discrepancies on the doctors & this dbc
-    hiddenDiscrepancyService.hideDiscrepancies(hideDiscrepancyDto);
+  public ResponseEntity<HideDiscrepancyResponseDto> hideDiscrepancies(
+      @Valid @RequestBody final HideDiscrepancyDto hideDiscrepancyDto) {
+    log.info("Request received to hide discrepancies: {}", hideDiscrepancyDto);
+
+    HideDiscrepancyResponseDto responseDto =
+        hiddenDiscrepancyService.hideDiscrepancies(hideDiscrepancyDto);
+    return ResponseEntity.ok(responseDto);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionController.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionController.java
@@ -47,6 +47,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.nhs.hee.tis.revalidation.connection.dto.ConnectionDto;
 import uk.nhs.hee.tis.revalidation.connection.dto.ConnectionSummaryDto;
+import uk.nhs.hee.tis.revalidation.connection.dto.HideDiscrepancyDto;
 import uk.nhs.hee.tis.revalidation.connection.dto.UpdateConnectionDto;
 import uk.nhs.hee.tis.revalidation.connection.dto.UpdateConnectionResponseDto;
 import uk.nhs.hee.tis.revalidation.connection.exception.ConnectionQueryException;
@@ -55,6 +56,7 @@ import uk.nhs.hee.tis.revalidation.connection.service.ConnectionService;
 import uk.nhs.hee.tis.revalidation.connection.service.DisconnectedElasticSearchService;
 import uk.nhs.hee.tis.revalidation.connection.service.DiscrepanciesElasticSearchService;
 import uk.nhs.hee.tis.revalidation.connection.service.ElasticsearchQueryHelper;
+import uk.nhs.hee.tis.revalidation.connection.service.HiddenDiscrepancyService;
 
 @Slf4j
 @RestController
@@ -90,6 +92,9 @@ public class ConnectionController {
 
   @Autowired
   private DisconnectedElasticSearchService disconnectedElasticSearchService;
+
+  @Autowired
+  private HiddenDiscrepancyService hiddenDiscrepancyService;
 
   /**
    * POST  /connections/add : Add a new connection.
@@ -385,5 +390,12 @@ public class ConnectionController {
         .searchForPage(searchQueryES, pageableAndSortable);
 
     return ResponseEntity.ok(connectionSummaryDto);
+  }
+
+  @PostMapping("/discrepancies/hidden")
+  public void hideDiscrepancies(@RequestBody final HideDiscrepancyDto hideDiscrepancyDto) {
+    log.info("Request received to hide discrepancies: {}", hideDiscrepancyDto.getDoctorGmcIds());
+    // todo: validate if the admin user has permission to hide discrepancies on the doctors & this dbc
+    hiddenDiscrepancyService.hideDiscrepancies(hideDiscrepancyDto);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/DoctorInfoDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/DoctorInfoDto.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.tis.revalidation.connection.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -34,6 +35,7 @@ import lombok.NoArgsConstructor;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DoctorInfoDto {
 
+  @NotBlank
   private String gmcId;
   private String currentDesignatedBodyCode;
   private String programmeOwnerDesignatedBodyCode;

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/HideDiscrepancyDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/HideDiscrepancyDto.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.connection.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A DTO class that has all fields for hiding a discrepancy.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HideDiscrepancyDto {
+
+  private List<String> doctorGmcIds;
+  private String hiddenForDesignatedBodyCode;
+  private String hiddenBy;
+  private String reason;
+}

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/HideDiscrepancyDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/HideDiscrepancyDto.java
@@ -21,9 +21,10 @@
 
 package uk.nhs.hee.tis.revalidation.connection.dto;
 
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -39,8 +40,11 @@ import lombok.NoArgsConstructor;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class HideDiscrepancyDto {
 
-  private List<String> doctorGmcIds;
+  @NotBlank(message = "Hidden For Designated body code must not be blank")
   private String hiddenForDesignatedBodyCode;
+  @NotEmpty
+  private List<DoctorInfoDto> doctors;
+  @NotBlank
   private String hiddenBy;
   private String reason;
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/HideDiscrepancyDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/HideDiscrepancyDto.java
@@ -40,11 +40,11 @@ import lombok.NoArgsConstructor;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class HideDiscrepancyDto {
 
-  @NotBlank(message = "Hidden For Designated body code must not be blank")
+  @NotBlank(message = "Hidden For Designated Body Code must not be blank")
   private String hiddenForDesignatedBodyCode;
   @NotEmpty
   private List<DoctorInfoDto> doctors;
-  @NotBlank
+  @NotBlank(message = "The user hiding discrepancies must be provided.")
   private String hiddenBy;
   private String reason;
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/HideDiscrepancyDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/HideDiscrepancyDto.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2026 Crown Copyright (Health Education England)
+ * Copyright 2026 Crown Copyright (NHS England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/HideDiscrepancyResponseDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/HideDiscrepancyResponseDto.java
@@ -41,11 +41,6 @@ public class HideDiscrepancyResponseDto {
 
   private String hiddenForDesignatedBodyCode;
 
-  private int requestedCount;
-  private int existingHiddenCount;
-  private int successfulCount;
-  private int failedCount;
-
   @Builder.Default
   private List<String> successfulHiddenGmcIds = new ArrayList<>();
   @Builder.Default

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/HideDiscrepancyResponseDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/HideDiscrepancyResponseDto.java
@@ -19,30 +19,37 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.revalidation.connection.repository;
+package uk.nhs.hee.tis.revalidation.connection.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.ArrayList;
 import java.util.List;
-import org.bson.types.ObjectId;
-import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.stereotype.Repository;
-import uk.nhs.hee.tis.revalidation.connection.entity.HiddenDiscrepancy;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
- * Repository interface for managing HiddenDiscrepancy entities in MongoDB.
+ * A DTO class that has all fields for the response of hiding discrepancies.
  */
-@Repository
-public interface HiddenDiscrepancyRepository extends MongoRepository<HiddenDiscrepancy, ObjectId> {
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HideDiscrepancyResponseDto {
 
-  /**
-   * Finds hidden discrepancies by GMC reference numbers and designated body code.
-   *
-   * @param gmcReferenceNumbers         the list of GMC reference numbers to search for
-   * @param hiddenForDesignatedBodyCode the designated body code for which the discrepancies are
-   *                                    hidden
-   * @return a list of HiddenDiscrepancy entities matching the criteria
-   */
-  List<HiddenDiscrepancy> findByGmcReferenceNumberInAndHiddenForDesignatedBodyCode(
-      List<String> gmcReferenceNumbers,
-      String hiddenForDesignatedBodyCode
-  );
+  private String hiddenForDesignatedBodyCode;
+
+  private int requestedCount;
+  private int existingHiddenCount;
+  private int successfulCount;
+  private int failedCount;
+
+  @Builder.Default
+  private List<String> successfulHiddenGmcIds = new ArrayList<>();
+  @Builder.Default
+  private List<String> failedToHideGmcIds = new ArrayList<>();
+  @Builder.Default
+  private List<String> existingHiddenGmcIds = new ArrayList<>();
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/HideDiscrepancyResponseDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/HideDiscrepancyResponseDto.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2026 Crown Copyright (Health Education England)
+ * Copyright 2026 Crown Copyright (NHS England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/entity/HiddenDiscrepancy.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/entity/HiddenDiscrepancy.java
@@ -26,7 +26,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -39,7 +38,9 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @NoArgsConstructor
 @Builder
 @Document(collection = "hiddenDiscrepancy")
-@CompoundIndex(def = "{'gmcId':1,'hiddenForDesignatedBodyCode':1}", name = "gmc_dbc_idx", unique = true)
+@CompoundIndex(def = "{'gmcId':1,'hiddenForDesignatedBodyCode':1}",
+    name = "gmc_dbc_idx",
+    unique = true)
 public class HiddenDiscrepancy {
 
   @Id

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/entity/HiddenDiscrepancy.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/entity/HiddenDiscrepancy.java
@@ -28,6 +28,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 /**
@@ -38,9 +39,11 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @NoArgsConstructor
 @Builder
 @Document(collection = "hiddenDiscrepancy")
+@CompoundIndex(def = "{'gmcId':1,'hiddenForDesignatedBodyCode':1}", name = "gmc_dbc_idx", unique = true)
 public class HiddenDiscrepancy {
+
   @Id
-  private ObjectId id;
+  private String id;
   private String gmcId;
   private String hiddenForDesignatedBodyCode;
   private String hiddenBy;

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/entity/HiddenDiscrepancy.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/entity/HiddenDiscrepancy.java
@@ -41,7 +41,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 public class HiddenDiscrepancy {
   @Id
   private ObjectId id;
-  private String gmcReferenceNumber;
+  private String gmcId;
   private String hiddenForDesignatedBodyCode;
   private String hiddenBy;
   private String reason;

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/entity/HiddenDiscrepancy.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/entity/HiddenDiscrepancy.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.connection.entity;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+/**
+ * A data class to handle hidden discrepancy status.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Document(collection = "hiddenDiscrepancy")
+public class HiddenDiscrepancy {
+  @Id
+  private ObjectId id;
+  private String gmcReferenceNumber;
+  private String hiddenForDesignatedBodyCode;
+  private String hiddenBy;
+  private String reason;
+  private LocalDateTime hiddenDateTime;
+}

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/entity/HiddenDiscrepancy.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/entity/HiddenDiscrepancy.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2026 Crown Copyright (Health Education England)
+ * Copyright 2026 Crown Copyright (NHS England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapper.java
@@ -43,7 +43,6 @@ public interface HiddenDiscrepancyMapper {
    * @return a HiddenDiscrepancy entity populated with data from the DTO and additional parameters
    */
   @Mapping(target = "id", ignore = true)
-  @Mapping(target = "gmcReferenceNumber", source = "gmcId")
   @Mapping(target = "hiddenDateTime", source = "batchTime")
   HiddenDiscrepancy toEntity(HideDiscrepancyDto dto, String gmcId, LocalDateTime batchTime);
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapper.java
@@ -42,6 +42,7 @@ public interface HiddenDiscrepancyMapper {
    * @param batchTime the timestamp when the hiding action is performed
    * @return a HiddenDiscrepancy entity populated with data from the DTO and additional parameters
    */
+  @Mapping(target = "id", ignore = true)
   @Mapping(target = "gmcReferenceNumber", source = "gmcId")
   @Mapping(target = "hiddenForDesignatedBodyCode", source = "dto.hiddenForDesignatedBodyCode")
   @Mapping(target = "hiddenBy", source = "dto.hiddenBy")

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapper.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.connection.mapper;
+
+import java.time.LocalDateTime;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import uk.nhs.hee.tis.revalidation.connection.dto.HideDiscrepancyDto;
+import uk.nhs.hee.tis.revalidation.connection.entity.HiddenDiscrepancy;
+
+/**
+ * Mapper interface for converting HideDiscrepancyDto objects to HiddenDiscrepancy entities.
+ * This mapper uses MapStruct to automatically generate the implementation code for the mapping.
+ */
+@Mapper(componentModel = "spring")
+public interface HiddenDiscrepancyMapper {
+
+  /**
+   * Maps a HideDiscrepancyDto to a HiddenDiscrepancy entity.
+   *
+   * @param dto the HideDiscrepancyDto containing the data to be mapped
+   * @param gmcId the GMC ID of the doctor for whom the discrepancy is being hidden
+   * @param batchTime the timestamp when the hiding action is performed
+   * @return a HiddenDiscrepancy entity populated with data from the DTO and additional parameters
+   */
+  @Mapping(target = "gmcReferenceNumber", source = "gmcId")
+  @Mapping(target = "hiddenForDesignatedBodyCode", source = "dto.hiddenForDesignatedBodyCode")
+  @Mapping(target = "hiddenBy", source = "dto.hiddenBy")
+  @Mapping(target = "reason", source = "dto.reason")
+  @Mapping(target = "hiddenDateTime", source = "batchTime")
+  HiddenDiscrepancy toEntity(HideDiscrepancyDto dto, String gmcId, LocalDateTime batchTime);
+}

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapper.java
@@ -44,9 +44,6 @@ public interface HiddenDiscrepancyMapper {
    */
   @Mapping(target = "id", ignore = true)
   @Mapping(target = "gmcReferenceNumber", source = "gmcId")
-  @Mapping(target = "hiddenForDesignatedBodyCode", source = "dto.hiddenForDesignatedBodyCode")
-  @Mapping(target = "hiddenBy", source = "dto.hiddenBy")
-  @Mapping(target = "reason", source = "dto.reason")
   @Mapping(target = "hiddenDateTime", source = "batchTime")
   HiddenDiscrepancy toEntity(HideDiscrepancyDto dto, String gmcId, LocalDateTime batchTime);
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapper.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2026 Crown Copyright (Health Education England)
+ * Copyright 2026 Crown Copyright (NHS England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/repository/HiddenDiscrepancyRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/repository/HiddenDiscrepancyRepository.java
@@ -1,0 +1,38 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.connection.repository;
+
+import java.util.List;
+import java.util.UUID;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import uk.nhs.hee.tis.revalidation.connection.entity.HiddenDiscrepancy;
+
+@Repository
+public interface HiddenDiscrepancyRepository extends MongoRepository<HiddenDiscrepancy, ObjectId> {
+
+  List<HiddenDiscrepancy> findByGmcReferenceNumberInAndHiddenForDesignatedBodyCode(
+      List<String> gmcReferenceNumbers,
+      String hiddenForDesignatedBodyCode
+  );
+}

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/repository/HiddenDiscrepancyRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/repository/HiddenDiscrepancyRepository.java
@@ -41,7 +41,7 @@ public interface HiddenDiscrepancyRepository extends MongoRepository<HiddenDiscr
    *                                    hidden
    * @return a list of HiddenDiscrepancy entities matching the criteria
    */
-  List<HiddenDiscrepancy> findByGmcReferenceNumberInAndHiddenForDesignatedBodyCode(
+  List<HiddenDiscrepancy> findByGmcIdInAndHiddenForDesignatedBodyCode(
       List<String> gmcReferenceNumbers,
       String hiddenForDesignatedBodyCode
   );

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/repository/HiddenDiscrepancyRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/repository/HiddenDiscrepancyRepository.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2026 Crown Copyright (Health Education England)
+ * Copyright 2026 Crown Copyright (NHS England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
@@ -78,6 +78,10 @@ public class HiddenDiscrepancyService {
     final List<String> newGmcIdsToHide = requestedGmcIds.stream()
         .filter(not(alreadyHidden::contains))
         .collect(Collectors.toList());
+    if (!alreadyHidden.isEmpty()) {
+      log.warn("Discrepancies for the following GMC IDs are already hidden for {}: {}",
+          hiddenForDbc, alreadyHidden);
+    }
     final List<String> savedGmcIds = new ArrayList<>();
 
     if (!newGmcIdsToHide.isEmpty()) {

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.connection.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.revalidation.connection.dto.HideDiscrepancyDto;
+import uk.nhs.hee.tis.revalidation.connection.entity.HiddenDiscrepancy;
+import uk.nhs.hee.tis.revalidation.connection.mapper.HiddenDiscrepancyMapper;
+import uk.nhs.hee.tis.revalidation.connection.repository.HiddenDiscrepancyRepository;
+
+@Slf4j
+@Service
+public class HiddenDiscrepancyService {
+
+  private final HiddenDiscrepancyRepository hiddenDiscrepancyRepository;
+  private final HiddenDiscrepancyMapper hiddenDiscrepancyMapper;
+
+  public HiddenDiscrepancyService(HiddenDiscrepancyRepository hiddenDiscrepancyRepository,
+      HiddenDiscrepancyMapper hiddenDiscrepancyMapper) {
+    this.hiddenDiscrepancyRepository = hiddenDiscrepancyRepository;
+    this.hiddenDiscrepancyMapper = hiddenDiscrepancyMapper;
+  }
+
+  public void hideDiscrepancies(HideDiscrepancyDto hideDiscrepancyDto) {
+    String dbc = hideDiscrepancyDto.getHiddenForDesignatedBodyCode();
+
+    // Preprocess the GMC IDs: remove null/empty, trim, and remove duplicates
+    List<String> normalizedGmcIds = hideDiscrepancyDto.getDoctorGmcIds().stream()
+        .filter(Objects::nonNull)
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .distinct()
+        .collect(Collectors.toList());
+
+    if (normalizedGmcIds.isEmpty()) {
+      return;
+    }
+    // Filter out GMC IDs that are already hidden for the given DBC
+    Set<String> existingGmcReferenceNumbersForDbc = hiddenDiscrepancyRepository
+        .findByGmcReferenceNumberInAndHiddenForDesignatedBodyCode(normalizedGmcIds, dbc).stream()
+        .map(HiddenDiscrepancy::getGmcReferenceNumber).collect(
+            Collectors.toSet());
+
+    List<String> newGmcIdsToHide = normalizedGmcIds.stream()
+        .filter(gmcId -> !existingGmcReferenceNumbersForDbc.contains(gmcId))
+        .collect(Collectors.toList());
+
+    if (newGmcIdsToHide.isEmpty()) {
+      return;
+    }
+
+    // Create new HiddenDiscrepancy entities and save them to the repository
+    LocalDateTime now = LocalDateTime.now();
+
+    List<HiddenDiscrepancy> newEntities = newGmcIdsToHide.stream()
+        .map(gmcId -> hiddenDiscrepancyMapper.toEntity(hideDiscrepancyDto, gmcId, now))
+        .collect(Collectors.toList());
+
+    hiddenDiscrepancyRepository.saveAll(newEntities);
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.revalidation.connection.service;
 
+import static java.util.function.Predicate.not;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -69,18 +71,36 @@ public class HiddenDiscrepancyService {
     final List<String> requestedGmcIds = extractRequestedGmcIds(dto);
 
     if (requestedGmcIds.isEmpty()) {
-      return emptyResponse(hiddenForDbc);
+      return HideDiscrepancyResponseDto.builder().hiddenForDesignatedBodyCode(hiddenForDbc).build();
     }
 
     final Set<String> alreadyHidden = findHiddenGmcIds(requestedGmcIds, hiddenForDbc);
-    final List<String> newGmcIdsToHide = filterNewGmcIds(requestedGmcIds, alreadyHidden);
+    final List<String> newGmcIdsToHide = requestedGmcIds.stream()
+        .filter(not(alreadyHidden::contains))
+        .collect(Collectors.toList());
+    final List<String> savedGmcIds = new ArrayList<>();
 
-    saveNewHiddenDiscrepancies(dto, newGmcIdsToHide);
+    if (!newGmcIdsToHide.isEmpty()) {
+      final LocalDateTime batchTime = LocalDateTime.now();
+      final List<HiddenDiscrepancy> newEntities = newGmcIdsToHide.stream()
+          .map(gmcId -> hiddenDiscrepancyMapper.toEntity(dto, gmcId, batchTime))
+          .collect(Collectors.toList());
 
-    // Retrieve the updated list of hidden GMC IDs for the given DBC after saving new entries
-    final Set<String> nowHidden = findHiddenGmcIds(requestedGmcIds, hiddenForDbc);
+      try {
+        savedGmcIds.addAll(hiddenDiscrepancyRepository.saveAll(newEntities).stream()
+            .map(HiddenDiscrepancy::getGmcId)
+            .collect(Collectors.toList()));
+      } catch (Exception e) {
+        log.error("Error saving hidden discrepancies to the db", e);
+      }
+    }
 
-    return buildResponse(hiddenForDbc, requestedGmcIds, alreadyHidden, nowHidden);
+    final List<String> failedToHide = newGmcIdsToHide.stream()
+        .filter(not(savedGmcIds::contains))
+        .collect(Collectors.toList());
+
+    return new HideDiscrepancyResponseDto(hiddenForDbc, savedGmcIds, failedToHide,
+        new ArrayList<>(alreadyHidden));
   }
 
   private List<String> extractRequestedGmcIds(HideDiscrepancyDto dto) {
@@ -94,68 +114,11 @@ public class HiddenDiscrepancyService {
         .collect(Collectors.toList());
   }
 
-  private HideDiscrepancyResponseDto emptyResponse(String hiddenForDbc) {
-    return HideDiscrepancyResponseDto.builder()
-        .hiddenForDesignatedBodyCode(hiddenForDbc)
-        .requestedCount(0)
-        .build();
-  }
-
   private Set<String> findHiddenGmcIds(List<String> gmcIds, String hiddenForDbc) {
     return hiddenDiscrepancyRepository
         .findByGmcIdInAndHiddenForDesignatedBodyCode(gmcIds, hiddenForDbc).stream()
         .map(HiddenDiscrepancy::getGmcId)
         .filter(Objects::nonNull)
         .collect(Collectors.toSet());
-  }
-
-  private List<String> filterNewGmcIds(List<String> requestedGmcIds, Set<String> alreadyHidden) {
-    return requestedGmcIds.stream()
-        .filter(gmcId -> !alreadyHidden.contains(gmcId))
-        .collect(Collectors.toList());
-  }
-
-  private void saveNewHiddenDiscrepancies(HideDiscrepancyDto dto, List<String> newGmcIdsToHide) {
-    if (newGmcIdsToHide.isEmpty()) {
-      return;
-    }
-
-    final LocalDateTime batchTime = LocalDateTime.now();
-    final List<HiddenDiscrepancy> newEntities = newGmcIdsToHide.stream()
-        .map(gmcId -> hiddenDiscrepancyMapper.toEntity(dto, gmcId, batchTime))
-        .collect(Collectors.toList());
-
-    try {
-      hiddenDiscrepancyRepository.saveAll(newEntities);
-    } catch (Exception e) {
-      log.error("Error saving hidden discrepancies to the db: {}", e.getMessage(), e);
-    }
-  }
-
-  private HideDiscrepancyResponseDto buildResponse(
-      String hiddenForDbc,
-      List<String> requestedGmcIds,
-      Set<String> alreadyHidden,
-      Set<String> nowHidden) {
-
-    final List<String> failedToHide = requestedGmcIds.stream()
-        .filter(gmcId -> !nowHidden.contains(gmcId))
-        .collect(Collectors.toList());
-
-    final List<String> successfullyHidden = requestedGmcIds.stream()
-        .filter(nowHidden::contains)
-        .filter(gmcId -> !alreadyHidden.contains(gmcId))
-        .collect(Collectors.toList());
-
-    return HideDiscrepancyResponseDto.builder()
-        .hiddenForDesignatedBodyCode(hiddenForDbc)
-        .requestedCount(requestedGmcIds.size())
-        .successfulCount(successfullyHidden.size())
-        .failedCount(failedToHide.size())
-        .existingHiddenCount(alreadyHidden.size())
-        .successfulHiddenGmcIds(successfullyHidden)
-        .failedToHideGmcIds(failedToHide)
-        .existingHiddenGmcIds(new ArrayList<>(alreadyHidden))
-        .build();
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
@@ -86,13 +86,9 @@ public class HiddenDiscrepancyService {
           .map(gmcId -> hiddenDiscrepancyMapper.toEntity(dto, gmcId, batchTime))
           .collect(Collectors.toList());
 
-      try {
-        savedGmcIds.addAll(hiddenDiscrepancyRepository.saveAll(newEntities).stream()
-            .map(HiddenDiscrepancy::getGmcId)
-            .collect(Collectors.toList()));
-      } catch (Exception e) {
-        log.error("Error saving hidden discrepancies to the db", e);
-      }
+      savedGmcIds.addAll(hiddenDiscrepancyRepository.saveAll(newEntities).stream()
+          .map(HiddenDiscrepancy::getGmcId)
+          .collect(Collectors.toList()));
     }
 
     final List<String> failedToHide = newGmcIdsToHide.stream()
@@ -118,7 +114,6 @@ public class HiddenDiscrepancyService {
     return hiddenDiscrepancyRepository
         .findByGmcIdInAndHiddenForDesignatedBodyCode(gmcIds, hiddenForDbc).stream()
         .map(HiddenDiscrepancy::getGmcId)
-        .filter(Objects::nonNull)
         .collect(Collectors.toSet());
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
@@ -103,8 +103,8 @@ public class HiddenDiscrepancyService {
 
   private Set<String> findHiddenGmcIds(List<String> gmcIds, String hiddenForDbc) {
     return hiddenDiscrepancyRepository
-        .findByGmcReferenceNumberInAndHiddenForDesignatedBodyCode(gmcIds, hiddenForDbc).stream()
-        .map(HiddenDiscrepancy::getGmcReferenceNumber)
+        .findByGmcIdInAndHiddenForDesignatedBodyCode(gmcIds, hiddenForDbc).stream()
+        .map(HiddenDiscrepancy::getGmcId)
         .filter(Objects::nonNull)
         .collect(Collectors.toSet());
   }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
@@ -22,17 +22,23 @@
 package uk.nhs.hee.tis.revalidation.connection.service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.revalidation.connection.dto.DoctorInfoDto;
 import uk.nhs.hee.tis.revalidation.connection.dto.HideDiscrepancyDto;
+import uk.nhs.hee.tis.revalidation.connection.dto.HideDiscrepancyResponseDto;
 import uk.nhs.hee.tis.revalidation.connection.entity.HiddenDiscrepancy;
 import uk.nhs.hee.tis.revalidation.connection.mapper.HiddenDiscrepancyMapper;
 import uk.nhs.hee.tis.revalidation.connection.repository.HiddenDiscrepancyRepository;
 
+/*
+ * Service class for managing hidden discrepancies related to doctors and designated bodies.
+ */
 @Slf4j
 @Service
 public class HiddenDiscrepancyService {
@@ -40,47 +46,116 @@ public class HiddenDiscrepancyService {
   private final HiddenDiscrepancyRepository hiddenDiscrepancyRepository;
   private final HiddenDiscrepancyMapper hiddenDiscrepancyMapper;
 
+  /**
+   * Constructs a new HiddenDiscrepancyService with the specified repository and mapper.
+   *
+   * @param hiddenDiscrepancyRepository the repository for managing hidden discrepancies
+   * @param hiddenDiscrepancyMapper     the mapper for converting between DTOs and entities
+   */
   public HiddenDiscrepancyService(HiddenDiscrepancyRepository hiddenDiscrepancyRepository,
       HiddenDiscrepancyMapper hiddenDiscrepancyMapper) {
     this.hiddenDiscrepancyRepository = hiddenDiscrepancyRepository;
     this.hiddenDiscrepancyMapper = hiddenDiscrepancyMapper;
   }
 
-  public void hideDiscrepancies(HideDiscrepancyDto hideDiscrepancyDto) {
-    String dbc = hideDiscrepancyDto.getHiddenForDesignatedBodyCode();
+  /**
+   * Hides discrepancies for a list of doctors based on the provided DTO.
+   *
+   * @param dto the DTO containing information about which discrepancies to hide
+   * @return a response DTO summarizing the results of the hide operation
+   */
+  public HideDiscrepancyResponseDto hideDiscrepancies(HideDiscrepancyDto dto) {
+    final String hiddenForDbc = dto.getHiddenForDesignatedBodyCode();
+    final List<String> requestedGmcIds = extractRequestedGmcIds(dto);
 
-    // Preprocess the GMC IDs: remove null/empty, trim, and remove duplicates
-    List<String> normalizedGmcIds = hideDiscrepancyDto.getDoctorGmcIds().stream()
+    if (requestedGmcIds.isEmpty()) {
+      return emptyResponse(hiddenForDbc);
+    }
+
+    final Set<String> alreadyHidden = findHiddenGmcIds(requestedGmcIds, hiddenForDbc);
+    final List<String> newGmcIdsToHide = filterNewGmcIds(requestedGmcIds, alreadyHidden);
+
+    saveNewHiddenDiscrepancies(dto, newGmcIdsToHide);
+
+    // Retrieve the updated list of hidden GMC IDs for the given DBC after saving new entries
+    final Set<String> nowHidden = findHiddenGmcIds(requestedGmcIds, hiddenForDbc);
+
+    return buildResponse(hiddenForDbc, requestedGmcIds, alreadyHidden, nowHidden);
+  }
+
+  private List<String> extractRequestedGmcIds(HideDiscrepancyDto dto) {
+    if (dto.getDoctors() == null) {
+      return List.of();
+    }
+    return dto.getDoctors().stream()
+        .map(DoctorInfoDto::getGmcId)
         .filter(Objects::nonNull)
-        .map(String::trim)
-        .filter(s -> !s.isEmpty())
         .distinct()
         .collect(Collectors.toList());
+  }
 
-    if (normalizedGmcIds.isEmpty()) {
-      return;
-    }
-    // Filter out GMC IDs that are already hidden for the given DBC
-    Set<String> existingGmcReferenceNumbersForDbc = hiddenDiscrepancyRepository
-        .findByGmcReferenceNumberInAndHiddenForDesignatedBodyCode(normalizedGmcIds, dbc).stream()
-        .map(HiddenDiscrepancy::getGmcReferenceNumber).collect(
-            Collectors.toSet());
+  private HideDiscrepancyResponseDto emptyResponse(String hiddenForDbc) {
+    return HideDiscrepancyResponseDto.builder()
+        .hiddenForDesignatedBodyCode(hiddenForDbc)
+        .requestedCount(0)
+        .build();
+  }
 
-    List<String> newGmcIdsToHide = normalizedGmcIds.stream()
-        .filter(gmcId -> !existingGmcReferenceNumbersForDbc.contains(gmcId))
+  private Set<String> findHiddenGmcIds(List<String> gmcIds, String hiddenForDbc) {
+    return hiddenDiscrepancyRepository
+        .findByGmcReferenceNumberInAndHiddenForDesignatedBodyCode(gmcIds, hiddenForDbc).stream()
+        .map(HiddenDiscrepancy::getGmcReferenceNumber)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toSet());
+  }
+
+  private List<String> filterNewGmcIds(List<String> requestedGmcIds, Set<String> alreadyHidden) {
+    return requestedGmcIds.stream()
+        .filter(gmcId -> !alreadyHidden.contains(gmcId))
         .collect(Collectors.toList());
+  }
 
+  private void saveNewHiddenDiscrepancies(HideDiscrepancyDto dto, List<String> newGmcIdsToHide) {
     if (newGmcIdsToHide.isEmpty()) {
       return;
     }
 
-    // Create new HiddenDiscrepancy entities and save them to the repository
-    LocalDateTime now = LocalDateTime.now();
-
-    List<HiddenDiscrepancy> newEntities = newGmcIdsToHide.stream()
-        .map(gmcId -> hiddenDiscrepancyMapper.toEntity(hideDiscrepancyDto, gmcId, now))
+    final LocalDateTime batchTime = LocalDateTime.now();
+    final List<HiddenDiscrepancy> newEntities = newGmcIdsToHide.stream()
+        .map(gmcId -> hiddenDiscrepancyMapper.toEntity(dto, gmcId, batchTime))
         .collect(Collectors.toList());
 
-    hiddenDiscrepancyRepository.saveAll(newEntities);
+    try {
+      hiddenDiscrepancyRepository.saveAll(newEntities);
+    } catch (Exception e) {
+      log.error("Error saving hidden discrepancies to the db: {}", e.getMessage(), e);
+    }
+  }
+
+  private HideDiscrepancyResponseDto buildResponse(
+      String hiddenForDbc,
+      List<String> requestedGmcIds,
+      Set<String> alreadyHidden,
+      Set<String> nowHidden) {
+
+    final List<String> failedToHide = requestedGmcIds.stream()
+        .filter(gmcId -> !nowHidden.contains(gmcId))
+        .collect(Collectors.toList());
+
+    final List<String> successfullyHidden = requestedGmcIds.stream()
+        .filter(nowHidden::contains)
+        .filter(gmcId -> !alreadyHidden.contains(gmcId))
+        .collect(Collectors.toList());
+
+    return HideDiscrepancyResponseDto.builder()
+        .hiddenForDesignatedBodyCode(hiddenForDbc)
+        .requestedCount(requestedGmcIds.size())
+        .successfulCount(successfullyHidden.size())
+        .failedCount(failedToHide.size())
+        .existingHiddenCount(alreadyHidden.size())
+        .successfulHiddenGmcIds(successfullyHidden)
+        .failedToHideGmcIds(failedToHide)
+        .existingHiddenGmcIds(new ArrayList<>(alreadyHidden))
+        .build();
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2026 Crown Copyright (Health Education England)
+ * Copyright 2026 Crown Copyright (NHS England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionControllerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionControllerTest.java
@@ -25,6 +25,7 @@ import static java.time.LocalDate.now;
 import static java.util.List.of;
 import static org.hamcrest.Matchers.hasItem;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.data.domain.Sort.Direction.ASC;
 import static org.springframework.data.domain.Sort.Direction.DESC;
@@ -40,8 +41,12 @@ import com.github.javafaker.Faker;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -53,6 +58,8 @@ import uk.nhs.hee.tis.revalidation.connection.dto.ConnectionHistoryDto;
 import uk.nhs.hee.tis.revalidation.connection.dto.ConnectionInfoDto;
 import uk.nhs.hee.tis.revalidation.connection.dto.ConnectionSummaryDto;
 import uk.nhs.hee.tis.revalidation.connection.dto.DoctorInfoDto;
+import uk.nhs.hee.tis.revalidation.connection.dto.HideDiscrepancyDto;
+import uk.nhs.hee.tis.revalidation.connection.dto.HideDiscrepancyResponseDto;
 import uk.nhs.hee.tis.revalidation.connection.dto.UpdateConnectionDto;
 import uk.nhs.hee.tis.revalidation.connection.dto.UpdateConnectionResponseDto;
 import uk.nhs.hee.tis.revalidation.connection.entity.ConnectionRequestType;
@@ -60,7 +67,7 @@ import uk.nhs.hee.tis.revalidation.connection.service.ConnectedElasticSearchServ
 import uk.nhs.hee.tis.revalidation.connection.service.ConnectionService;
 import uk.nhs.hee.tis.revalidation.connection.service.DisconnectedElasticSearchService;
 import uk.nhs.hee.tis.revalidation.connection.service.DiscrepanciesElasticSearchService;
-
+import uk.nhs.hee.tis.revalidation.connection.service.HiddenDiscrepancyService;
 
 @WebMvcTest(ConnectionController.class)
 class ConnectionControllerTest {
@@ -76,6 +83,7 @@ class ConnectionControllerTest {
   private static final String EMPTY_STRING = "";
   private static final LocalDate EMPTY_DATE = null;
   private static final String PROGRAMME_NAME = "programmeName";
+  private static final String ADMIN_NAME = "admin";
   private final Faker faker = new Faker();
   @Autowired
   private MockMvc mockMvc;
@@ -89,6 +97,8 @@ class ConnectionControllerTest {
   private ConnectedElasticSearchService connectedElasticSearchService;
   @MockBean
   private DisconnectedElasticSearchService disconnectedElasticSearchService;
+  @MockBean
+  private HiddenDiscrepancyService hiddenDiscrepancyService;
 
   private String changeReason;
   private String designatedBodyCode;
@@ -432,6 +442,101 @@ class ConnectionControllerTest {
         .andExpect(status().isOk())
         .andExpect(
             jsonPath("$.connections.[*].tcsPersonId").value(hasItem(personId1.intValue())));
+  }
+
+  static Stream<Arguments> invalidHideDiscrepancyRequests() {
+    var validDoctors = List.of(DoctorInfoDto.builder().build());
+    return Stream.of(
+        Arguments.of(
+            HideDiscrepancyDto.builder()
+                .hiddenForDesignatedBodyCode(null)
+                .hiddenBy(ADMIN_NAME)
+                .doctors(validDoctors)
+                .build(),
+            "hiddenForDesignatedBodyCode is null"
+        ),
+        Arguments.of(
+            HideDiscrepancyDto.builder()
+                .hiddenForDesignatedBodyCode("")
+                .hiddenBy(ADMIN_NAME)
+                .doctors(validDoctors)
+                .build(),
+            "hiddenForDesignatedBodyCode is blank"
+        ),
+        Arguments.of(
+            HideDiscrepancyDto.builder()
+                .hiddenForDesignatedBodyCode(DESIGNATED_BODY_CODES)
+                .hiddenBy(ADMIN_NAME)
+                .doctors(null)
+                .build(),
+            "doctors is null"
+        ),
+        Arguments.of(
+            HideDiscrepancyDto.builder()
+                .hiddenForDesignatedBodyCode(DESIGNATED_BODY_CODES)
+                .hiddenBy(ADMIN_NAME)
+                .doctors(List.of())
+                .build(),
+            "doctors is empty"
+        ),
+        Arguments.of(
+            HideDiscrepancyDto.builder()
+                .hiddenForDesignatedBodyCode(DESIGNATED_BODY_CODES)
+                .hiddenBy(null)
+                .doctors(validDoctors)
+                .build(),
+            "hiddenBy is null"
+        ),
+        Arguments.of(
+            HideDiscrepancyDto.builder()
+                .hiddenForDesignatedBodyCode(DESIGNATED_BODY_CODES)
+                .hiddenBy(" ")
+                .doctors(validDoctors)
+                .build(),
+            "hiddenBy is blank"
+        )
+    );
+  }
+
+  @Test
+  void shouldHideDiscrepancies() throws Exception {
+    // given
+    DoctorInfoDto doctor = DoctorInfoDto.builder().gmcId(gmcId)
+        .currentDesignatedBodyCode(designatedBodyCode).build();
+    final var hideDiscrepancyDto = HideDiscrepancyDto.builder()
+        .hiddenForDesignatedBodyCode(DESIGNATED_BODY_CODES)
+        .doctors(List.of(doctor)).hiddenBy(ADMIN_NAME).build();
+
+    final var response = HideDiscrepancyResponseDto.builder()
+        .hiddenForDesignatedBodyCode(designatedBodyCode)
+        .requestedCount(1).failedCount(0).successfulCount(1).existingHiddenCount(0)
+        .successfulHiddenGmcIds(List.of(gmcId))
+        .build();
+
+    when(hiddenDiscrepancyService.hideDiscrepancies(any(HideDiscrepancyDto.class)))
+        .thenReturn(response);
+
+    // when & then
+    this.mockMvc.perform(post("/api/connections/discrepancies/hidden")
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsBytes(hideDiscrepancyDto)))
+        .andExpect(status().isOk())
+        .andExpect(content().json(objectMapper.writeValueAsString(response)));
+  }
+
+  @ParameterizedTest(name = "invalid request: {1}")
+  @MethodSource("invalidHideDiscrepancyRequests")
+  void shouldReturnBadRequestForInvalidHideDiscrepancyRequests(
+      HideDiscrepancyDto request, String description) throws Exception {
+
+    this.mockMvc.perform(post("/api/connections/discrepancies/hidden")
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsBytes(request)))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(hiddenDiscrepancyService);
   }
 
   private ConnectionDto prepareConnectionDto() {

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionControllerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionControllerTest.java
@@ -509,7 +509,6 @@ class ConnectionControllerTest {
 
     final var response = HideDiscrepancyResponseDto.builder()
         .hiddenForDesignatedBodyCode(designatedBodyCode)
-        .requestedCount(1).failedCount(0).successfulCount(1).existingHiddenCount(0)
         .successfulHiddenGmcIds(List.of(gmcId))
         .build();
 

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapperTest.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.connection.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import uk.nhs.hee.tis.revalidation.connection.dto.HideDiscrepancyDto;
+import uk.nhs.hee.tis.revalidation.connection.entity.HiddenDiscrepancy;
+
+class HiddenDiscrepancyMapperTest {
+
+  private static final String DBC = "DB123";
+  private static final String HIDDEN_BY = "admin";
+  private static final String REASON = "reason for hiding";
+  private static final String GMC_ID = "1-ABCDE";
+  private static final LocalDateTime BATCH_TIME = LocalDateTime.of(2026, 3, 5, 10, 0, 0);
+
+  private final HiddenDiscrepancyMapper mapper =
+      Mappers.getMapper(HiddenDiscrepancyMapper.class);
+
+  @Test
+  void shouldMapAllFieldsAndIgnoreIdWhenToEntityCalled() {
+    // given
+    HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
+        .hiddenForDesignatedBodyCode(DBC)
+        .hiddenBy(HIDDEN_BY)
+        .reason(REASON)
+        .doctors(List.of()) // doctors list is not mapped, so can be empty
+        .build();
+
+    // when
+    HiddenDiscrepancy entity = mapper.toEntity(dto, GMC_ID, BATCH_TIME);
+
+    // then
+    assertThat(entity).isNotNull();
+
+    // id ignored
+    assertThat(entity.getId()).isNull();
+
+    // mapped fields
+    assertThat(entity.getGmcReferenceNumber()).isEqualTo(GMC_ID);
+    assertThat(entity.getHiddenForDesignatedBodyCode()).isEqualTo(dto.getHiddenForDesignatedBodyCode());
+    assertThat(entity.getHiddenBy()).isEqualTo(dto.getHiddenBy());
+    assertThat(entity.getReason()).isEqualTo(dto.getReason());
+    assertThat(entity.getHiddenDateTime()).isEqualTo(BATCH_TIME);
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapperTest.java
@@ -25,7 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 import uk.nhs.hee.tis.revalidation.connection.dto.HideDiscrepancyDto;
@@ -63,7 +62,8 @@ class HiddenDiscrepancyMapperTest {
 
     // mapped fields
     assertThat(entity.getGmcReferenceNumber()).isEqualTo(GMC_ID);
-    assertThat(entity.getHiddenForDesignatedBodyCode()).isEqualTo(dto.getHiddenForDesignatedBodyCode());
+    assertThat(entity.getHiddenForDesignatedBodyCode()).isEqualTo(
+        dto.getHiddenForDesignatedBodyCode());
     assertThat(entity.getHiddenBy()).isEqualTo(dto.getHiddenBy());
     assertThat(entity.getReason()).isEqualTo(dto.getReason());
     assertThat(entity.getHiddenDateTime()).isEqualTo(BATCH_TIME);

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapperTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2026 Crown Copyright (Health Education England)
+ * Copyright 2026 Crown Copyright (NHS England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapperTest.java
@@ -61,7 +61,7 @@ class HiddenDiscrepancyMapperTest {
     assertThat(entity.getId()).isNull();
 
     // mapped fields
-    assertThat(entity.getGmcReferenceNumber()).isEqualTo(GMC_ID);
+    assertThat(entity.getGmcId()).isEqualTo(GMC_ID);
     assertThat(entity.getHiddenForDesignatedBodyCode()).isEqualTo(
         dto.getHiddenForDesignatedBodyCode());
     assertThat(entity.getHiddenBy()).isEqualTo(dto.getHiddenBy());

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
@@ -257,7 +257,7 @@ class HiddenDiscrepancyServiceTest {
   }
 
   /**
-   * Simple entity builder for repository return values (only gmcId is relevant for service logic)
+   * Simple entity builder for repository return values (only gmcId is relevant for service logic).
    *
    * @param gmcId The GMC Number for the returned object
    * @return The HiddenDiscrepancy

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
@@ -1,0 +1,364 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.connection.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.hee.tis.revalidation.connection.dto.DoctorInfoDto;
+import uk.nhs.hee.tis.revalidation.connection.dto.HideDiscrepancyDto;
+import uk.nhs.hee.tis.revalidation.connection.dto.HideDiscrepancyResponseDto;
+import uk.nhs.hee.tis.revalidation.connection.entity.HiddenDiscrepancy;
+import uk.nhs.hee.tis.revalidation.connection.mapper.HiddenDiscrepancyMapper;
+import uk.nhs.hee.tis.revalidation.connection.repository.HiddenDiscrepancyRepository;
+
+@ExtendWith(MockitoExtension.class)
+class HiddenDiscrepancyServiceTest {
+
+  private static final String DBC = "1-ABCDE";
+  private static final String HIDDEN_BY = "admin";
+  private static final String REASON = "reason";
+
+  @Captor
+  ArgumentCaptor<List<HiddenDiscrepancy>> saveCaptor;
+  @Captor
+  ArgumentCaptor<List<String>> gmcIdsCaptor;
+  @Mock
+  private HiddenDiscrepancyRepository hiddenDiscrepancyRepository;
+  @Mock
+  private HiddenDiscrepancyMapper hiddenDiscrepancyMapper;
+  @InjectMocks
+  private HiddenDiscrepancyService service;
+
+  @Test
+  void shouldReturnEmptyResponseWhenDoctorsIsNull() {
+    HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
+        .hiddenForDesignatedBodyCode(DBC)
+        .hiddenBy(HIDDEN_BY)
+        .reason(REASON)
+        .doctors(null)
+        .build();
+
+    HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
+
+    assertResponseListCounts(response, 0, 0, 0, 0);
+    assertResponseLists(response, List.of(), List.of(), List.of());
+
+    verifyNoInteractions(hiddenDiscrepancyRepository);
+    verifyNoInteractions(hiddenDiscrepancyMapper);
+  }
+
+  @Test
+  void shouldReturnEmptyResponseWhenDoctorsIsEmpty() {
+    HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
+        .hiddenForDesignatedBodyCode(DBC)
+        .hiddenBy(HIDDEN_BY)
+        .reason(REASON)
+        .doctors(List.of())
+        .build();
+
+    HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
+
+    assertResponseListCounts(response, 0, 0, 0, 0);
+    assertResponseLists(response, List.of(), List.of(), List.of());
+
+    verifyNoInteractions(hiddenDiscrepancyRepository);
+    verifyNoInteractions(hiddenDiscrepancyMapper);
+  }
+
+  @Test
+  void shouldReturnEmptyResponseWhenAllDoctorsHaveNullGmcId() {
+    HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
+        .hiddenForDesignatedBodyCode(DBC)
+        .hiddenBy(HIDDEN_BY)
+        .reason(REASON)
+        .doctors(List.of(doc(null), doc(null)))
+        .build();
+
+    HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
+
+    assertResponseListCounts(response, 0, 0, 0, 0);
+    assertResponseLists(response, List.of(), List.of(), List.of());
+
+    verifyNoInteractions(hiddenDiscrepancyRepository);
+    verifyNoInteractions(hiddenDiscrepancyMapper);
+  }
+
+  @Test
+  void shouldNotSaveAndShouldReturnExistingHiddenWhenAllRequestedAreAlreadyHidden() {
+    HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
+        .hiddenForDesignatedBodyCode(DBC)
+        .hiddenBy(HIDDEN_BY)
+        .reason(REASON)
+        .doctors(List.of(doc("GMC1"), doc("GMC2")))
+        .build();
+
+    when(hiddenDiscrepancyRepository
+        .findByGmcReferenceNumberInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
+        .thenReturn(List.of(entity("GMC1"), entity("GMC2"))) // alreadyHidden
+        .thenReturn(List.of(entity("GMC1"), entity("GMC2"))); // nowHidden
+
+    HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
+
+    assertResponseListCounts(response, 2, 2, 0, 0);
+    assertResponseLists(response, List.of(), List.of(), List.of("GMC1", "GMC2"));
+
+    verify(hiddenDiscrepancyRepository, never()).saveAll(anyList());
+    verifyNoInteractions(hiddenDiscrepancyMapper);
+  }
+
+  @Test
+  void shouldSaveOnlyNewGmcIdsAndReturnSuccessfulAndExistingListsWhenSomeAreNew() {
+    HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
+        .hiddenForDesignatedBodyCode(DBC)
+        .hiddenBy(HIDDEN_BY)
+        .reason(REASON)
+        .doctors(List.of(doc("GMC1"), doc("GMC2"), doc("GMC3")))
+        .build();
+
+    when(hiddenDiscrepancyRepository
+        .findByGmcReferenceNumberInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
+        .thenReturn(List.of(entity("GMC1"))) // alreadyHidden
+        .thenReturn(List.of(entity("GMC1"), entity("GMC2"), entity("GMC3"))); // nowHidden
+
+    mockMapperToReturnRealEntity();
+
+    // capture saveAll payload
+    HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
+
+    assertResponseListCounts(response, 3, 1, 2, 0);
+    assertResponseLists(response, List.of("GMC2", "GMC3"), List.of(), List.of("GMC1"));
+
+    verify(hiddenDiscrepancyRepository).saveAll(saveCaptor.capture());
+    List<HiddenDiscrepancy> saved = saveCaptor.getValue();
+    assertSavedEntities(saved, Set.of("GMC2", "GMC3"), dto);
+
+    // mapper should be called only for new ids
+    verify(hiddenDiscrepancyMapper, never()).toEntity(eq(dto), eq("GMC1"),
+        any(LocalDateTime.class));
+    verify(hiddenDiscrepancyMapper).toEntity(eq(dto), eq("GMC2"), any(LocalDateTime.class));
+    verify(hiddenDiscrepancyMapper).toEntity(eq(dto), eq("GMC3"), any(LocalDateTime.class));
+  }
+
+  @Test
+  void shouldContinueAndReturnListsComputedFromDbWhenSaveAllThrowsException() {
+    HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
+        .hiddenForDesignatedBodyCode(DBC)
+        .hiddenBy(HIDDEN_BY)
+        .reason(REASON)
+        .doctors(List.of(doc("GMC1"), doc("GMC2")))
+        .build();
+
+    when(hiddenDiscrepancyRepository
+        .findByGmcReferenceNumberInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
+        .thenReturn(List.of())                // alreadyHidden
+        .thenReturn(List.of(entity("GMC1"))); // nowHidden only has GMC1
+
+    mockMapperToReturnRealEntity();
+    doThrow(new RuntimeException("db down")).when(hiddenDiscrepancyRepository).saveAll(anyList());
+
+    HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
+
+    assertResponseListCounts(response, 2, 0, 1, 1);
+    assertResponseLists(response, List.of("GMC1"), List.of("GMC2"), List.of());
+
+    verify(hiddenDiscrepancyRepository).saveAll(anyList());
+  }
+
+  @Test
+  void shouldReturnFailedListWhenDbDoesNotReturnAllAsHiddenAfterSaveAttempt() {
+    HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
+        .hiddenForDesignatedBodyCode(DBC)
+        .hiddenBy(HIDDEN_BY)
+        .reason(REASON)
+        .doctors(List.of(doc("GMC1"), doc("GMC2"), doc("GMC3")))
+        .build();
+
+    when(hiddenDiscrepancyRepository
+        .findByGmcReferenceNumberInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
+        .thenReturn(List.of()) // alreadyHidden
+        .thenReturn(List.of(entity("GMC1"), entity("GMC2"))); // nowHidden missing GMC3
+
+    mockMapperToReturnRealEntity();
+
+    HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
+
+    assertResponseListCounts(response, 3, 0, 2, 1);
+    assertResponseLists(response, List.of("GMC1", "GMC2"), List.of("GMC3"), List.of()
+    );
+  }
+
+  @Test
+  void shouldDeduplicateRequestedGmcIdsAndReturnListsWithoutDuplicatesWhenInputContainsDuplicates() {
+    HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
+        .hiddenForDesignatedBodyCode(DBC)
+        .hiddenBy(HIDDEN_BY)
+        .reason(REASON)
+        .doctors(List.of(doc("GMC1"), doc("GMC1"), doc("GMC2")))
+        .build();
+
+    // capture the gmcIds list passed into repository (to ensure distinct() is applied)
+    when(hiddenDiscrepancyRepository
+        .findByGmcReferenceNumberInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
+        .thenReturn(List.of()) // alreadyHidden
+        .thenReturn(List.of(entity("GMC1"), entity("GMC2"))); // nowHidden
+
+    mockMapperToReturnRealEntity();
+
+    HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
+
+    assertResponseListCounts(response, 2, 0, 2, 0);
+    assertResponseLists(response, List.of("GMC1", "GMC2"), List.of(), List.of());
+
+    verify(hiddenDiscrepancyRepository, times(2))
+        .findByGmcReferenceNumberInAndHiddenForDesignatedBodyCode(gmcIdsCaptor.capture(), eq(DBC));
+
+    List<String> requestedGmcsAtFirstQuery = gmcIdsCaptor.getAllValues().get(0);
+    assertEquals(2, requestedGmcsAtFirstQuery.size());
+    assertListContainsExactlyIgnoringOrder(requestedGmcsAtFirstQuery, List.of("GMC1", "GMC2"));
+
+    verify(hiddenDiscrepancyMapper, times(1)).toEntity(eq(dto), eq("GMC1"),
+        any(LocalDateTime.class));
+    verify(hiddenDiscrepancyMapper, times(1)).toEntity(eq(dto), eq("GMC2"),
+        any(LocalDateTime.class));
+  }
+
+  // -------------------- Helpers --------------------
+
+  private DoctorInfoDto doc(String gmc) {
+    DoctorInfoDto d = mock(DoctorInfoDto.class);
+    when(d.getGmcId()).thenReturn(gmc);
+    return d;
+  }
+
+  // Simple entity builder for repository return values (only gmc is relevant for service logic)
+  private HiddenDiscrepancy entity(String gmc) {
+    return HiddenDiscrepancy.builder().gmcReferenceNumber(gmc).build();
+  }
+
+  // Mock mapper to return a real entity based on the input dto and gmcId
+  private void mockMapperToReturnRealEntity() {
+    when(hiddenDiscrepancyMapper.toEntity(any(HideDiscrepancyDto.class), anyString(),
+        any(LocalDateTime.class)))
+        .thenAnswer(inv -> {
+          HideDiscrepancyDto dto = inv.getArgument(0, HideDiscrepancyDto.class);
+          String gmcId = inv.getArgument(1, String.class);
+          LocalDateTime batchTime = inv.getArgument(2, LocalDateTime.class);
+
+          return HiddenDiscrepancy.builder()
+              .gmcReferenceNumber(gmcId)
+              .hiddenForDesignatedBodyCode(dto.getHiddenForDesignatedBodyCode())
+              .hiddenBy(dto.getHiddenBy())
+              .reason(dto.getReason())
+              .hiddenDateTime(batchTime)
+              .build();
+        });
+  }
+
+  // Assert the counts in the response and that the lists are non-null (but not their contents)
+  private void assertResponseListCounts(
+      HideDiscrepancyResponseDto response,
+      int expectedRequested,
+      int expectedExisting,
+      int expectedSuccessful,
+      int expectedFailed) {
+
+    assertNotNull(response);
+    assertEquals(HiddenDiscrepancyServiceTest.DBC, response.getHiddenForDesignatedBodyCode());
+
+    assertEquals(expectedRequested, response.getRequestedCount());
+    assertEquals(expectedExisting, response.getExistingHiddenCount());
+    assertEquals(expectedSuccessful, response.getSuccessfulCount());
+    assertEquals(expectedFailed, response.getFailedCount());
+
+    assertNotNull(response.getSuccessfulHiddenGmcIds());
+    assertNotNull(response.getFailedToHideGmcIds());
+    assertNotNull(response.getExistingHiddenGmcIds());
+  }
+
+  // Assert the contents of the three lists in the response (ignoring order)
+  private void assertResponseLists(HideDiscrepancyResponseDto response,
+      List<String> expectedSuccessful,
+      List<String> expectedFailed,
+      List<String> expectedExisting) {
+
+    assertListContainsExactlyIgnoringOrder(response.getSuccessfulHiddenGmcIds(),
+        expectedSuccessful);
+    assertListContainsExactlyIgnoringOrder(response.getFailedToHideGmcIds(), expectedFailed);
+    assertListContainsExactlyIgnoringOrder(response.getExistingHiddenGmcIds(), expectedExisting);
+  }
+
+  private void assertListContainsExactlyIgnoringOrder(List<String> actual, List<String> expected) {
+    assertNotNull(actual);
+    assertNotNull(expected);
+
+    assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  // Assert that the saved entities have the expected GMCs, correct mapping from dto,
+  // and consistent batchTime
+  private void assertSavedEntities(List<HiddenDiscrepancy> saved, Set<String> expectedGmcs,
+      HideDiscrepancyDto dto) {
+    assertNotNull(saved);
+    assertEquals(expectedGmcs.size(), saved.size());
+
+    Set<String> savedGmcs = saved.stream()
+        .map(HiddenDiscrepancy::getGmcReferenceNumber)
+        .collect(Collectors.toSet());
+    assertEquals(expectedGmcs, savedGmcs);
+
+    for (HiddenDiscrepancy hd : saved) {
+      assertEquals(dto.getHiddenForDesignatedBodyCode(), hd.getHiddenForDesignatedBodyCode());
+      assertEquals(dto.getHiddenBy(), hd.getHiddenBy());
+      assertEquals(dto.getReason(), hd.getReason());
+      assertNotNull(hd.getHiddenDateTime());
+    }
+
+    Set<LocalDateTime> times = saved.stream()
+        .map(HiddenDiscrepancy::getHiddenDateTime)
+        .collect(Collectors.toSet());
+    assertEquals(1, times.size());
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
@@ -184,13 +184,6 @@ class HiddenDiscrepancyServiceTest {
 
   @Test
   void shouldContinueAndReturnListsComputedFromDbWhenSaveAllThrowsException() {
-    HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
-        .hiddenForDesignatedBodyCode(DBC)
-        .hiddenBy(HIDDEN_BY)
-        .reason(REASON)
-        .doctors(List.of(doc("GMC1"), doc("GMC2")))
-        .build();
-
     when(hiddenDiscrepancyRepository
         .findByGmcReferenceNumberInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
         .thenReturn(List.of())                // alreadyHidden
@@ -198,6 +191,13 @@ class HiddenDiscrepancyServiceTest {
 
     mockMapperToReturnRealEntity();
     doThrow(new RuntimeException("db down")).when(hiddenDiscrepancyRepository).saveAll(anyList());
+
+    HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
+        .hiddenForDesignatedBodyCode(DBC)
+        .hiddenBy(HIDDEN_BY)
+        .reason(REASON)
+        .doctors(List.of(doc("GMC1"), doc("GMC2")))
+        .build();
 
     HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
 
@@ -231,7 +231,7 @@ class HiddenDiscrepancyServiceTest {
   }
 
   @Test
-  void shouldDeduplicateRequestedGmcIdsAndReturnListsWithoutDuplicatesWhenInputContainsDuplicates() {
+  void shouldDedupRequestedGmcIdsAndReturnListsWithoutDuplicatesWhenInputContainsDuplicates() {
     HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
         .hiddenForDesignatedBodyCode(DBC)
         .hiddenBy(HIDDEN_BY)

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
@@ -28,7 +28,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -129,7 +128,7 @@ class HiddenDiscrepancyServiceTest {
 
   @Test
   void shouldSaveOnlyNewGmcIdsAndReturnSuccessfulAndExistingListsWhenSomeAreNew() {
-    HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
+    final HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
         .hiddenForDesignatedBodyCode(DBC)
         .hiddenBy(HIDDEN_BY)
         .reason(REASON)
@@ -171,7 +170,7 @@ class HiddenDiscrepancyServiceTest {
 
     mockMapperToReturnRealEntity();
 
-    HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
+    final HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
         .hiddenForDesignatedBodyCode(DBC)
         .hiddenBy(HIDDEN_BY)
         .reason(REASON)
@@ -189,7 +188,7 @@ class HiddenDiscrepancyServiceTest {
 
   @Test
   void shouldReturnFailedListWhenDbDoesNotReturnAllAsHiddenAfterSaveAttempt() {
-    HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
+    final HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
         .hiddenForDesignatedBodyCode(DBC)
         .hiddenBy(HIDDEN_BY)
         .reason(REASON)
@@ -213,7 +212,7 @@ class HiddenDiscrepancyServiceTest {
 
   @Test
   void shouldDedupRequestedGmcIdsAndReturnListsWithoutDuplicatesWhenInputContainsDuplicates() {
-    HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
+    final HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
         .hiddenForDesignatedBodyCode(DBC)
         .hiddenBy(HIDDEN_BY)
         .reason(REASON)
@@ -287,12 +286,12 @@ class HiddenDiscrepancyServiceTest {
   }
 
   /**
-   * Assert the counts in the response and that the lists are non-null (but not their contents)
+   * Assert the counts in the response and that the lists are non-null (but not their contents).
    *
-   * @param response
-   * @param expectedExisting
-   * @param expectedSuccessful
-   * @param expectedFailed
+   * @param response           the service response containing details of hidden discrepancies
+   * @param expectedExisting   the expected number of existing discrepancies
+   * @param expectedSuccessful the expected number of hide discrepancy updates to succeed
+   * @param expectedFailed     the expected number of hide discrepancy updates to succeed
    */
   private void assertResponseListCounts(HideDiscrepancyResponseDto response, int expectedExisting,
       int expectedSuccessful, int expectedFailed) {
@@ -309,12 +308,12 @@ class HiddenDiscrepancyServiceTest {
   }
 
   /**
-   * Assert the contents of the three lists in the response (ignoring order)
+   * Assert the contents of the three lists in the response (ignoring order).
    *
-   * @param response
-   * @param expectedSuccessful
-   * @param expectedFailed
-   * @param expectedExisting
+   * @param response           the service response containing details of hidden discrepancies
+   * @param expectedExisting   the expected number of existing discrepancies
+   * @param expectedSuccessful the expected number of hide discrepancy updates to succeed
+   * @param expectedFailed     the expected number of hide discrepancy updates to succeed
    */
   private void assertResponseLists(HideDiscrepancyResponseDto response,
       List<String> expectedSuccessful,
@@ -336,11 +335,11 @@ class HiddenDiscrepancyServiceTest {
 
   /**
    * Assert that the saved entities have the expected GMCs, correct mapping from dto and consistent
-   * batchTime
+   * batchTime.
    *
-   * @param saved
-   * @param expectedGmcs
-   * @param dto
+   * @param saved        the entities saved
+   * @param expectedGmcs the expected GMC numbers to have been saved
+   * @param dto          the dto to verify
    */
   private void assertSavedEntities(List<HiddenDiscrepancy> saved, Set<String> expectedGmcs,
       HideDiscrepancyDto dto) {

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
@@ -40,8 +40,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
@@ -72,59 +75,34 @@ class HiddenDiscrepancyServiceTest {
   @InjectMocks
   private HiddenDiscrepancyService service;
 
-  @Test
-  void shouldReturnEmptyResponseWhenDoctorsIsNull() {
+  @ParameterizedTest
+  @MethodSource("invalidDoctorDtosSupplier")
+  void shouldReturnEmptyResponseWhenDoctorsInvalid(List<DoctorInfoDto> doctors) {
     HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
         .hiddenForDesignatedBodyCode(DBC)
         .hiddenBy(HIDDEN_BY)
         .reason(REASON)
-        .doctors(null)
+        .doctors(doctors)
         .build();
 
     HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
 
-    assertResponseListCounts(response, 0, 0, 0, 0);
+    assertResponseListCounts(response, 0, 0, 0);
     assertResponseLists(response, List.of(), List.of(), List.of());
 
     verifyNoInteractions(hiddenDiscrepancyRepository);
     verifyNoInteractions(hiddenDiscrepancyMapper);
   }
 
-  @Test
-  void shouldReturnEmptyResponseWhenDoctorsIsEmpty() {
-    HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
-        .hiddenForDesignatedBodyCode(DBC)
-        .hiddenBy(HIDDEN_BY)
-        .reason(REASON)
-        .doctors(List.of())
-        .build();
-
-    HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
-
-    assertResponseListCounts(response, 0, 0, 0, 0);
-    assertResponseLists(response, List.of(), List.of(), List.of());
-
-    verifyNoInteractions(hiddenDiscrepancyRepository);
-    verifyNoInteractions(hiddenDiscrepancyMapper);
+  private static Stream<List<DoctorInfoDto>> invalidDoctorDtosSupplier() {
+    return Stream.of(
+        null,
+        List.of(),
+        List.of(doc(null)),
+        List.of(doc(null), doc(null))
+    );
   }
 
-  @Test
-  void shouldReturnEmptyResponseWhenAllDoctorsHaveNullGmcId() {
-    HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
-        .hiddenForDesignatedBodyCode(DBC)
-        .hiddenBy(HIDDEN_BY)
-        .reason(REASON)
-        .doctors(List.of(doc(null), doc(null)))
-        .build();
-
-    HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
-
-    assertResponseListCounts(response, 0, 0, 0, 0);
-    assertResponseLists(response, List.of(), List.of(), List.of());
-
-    verifyNoInteractions(hiddenDiscrepancyRepository);
-    verifyNoInteractions(hiddenDiscrepancyMapper);
-  }
 
   @Test
   void shouldNotSaveAndShouldReturnExistingHiddenWhenAllRequestedAreAlreadyHidden() {
@@ -136,13 +114,13 @@ class HiddenDiscrepancyServiceTest {
         .build();
 
     when(hiddenDiscrepancyRepository
-        .findByGmcReferenceNumberInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
+        .findByGmcIdInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
         .thenReturn(List.of(entity("GMC1"), entity("GMC2"))) // alreadyHidden
         .thenReturn(List.of(entity("GMC1"), entity("GMC2"))); // nowHidden
 
     HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
 
-    assertResponseListCounts(response, 2, 2, 0, 0);
+    assertResponseListCounts(response, 2, 0, 0);
     assertResponseLists(response, List.of(), List.of(), List.of("GMC1", "GMC2"));
 
     verify(hiddenDiscrepancyRepository, never()).saveAll(anyList());
@@ -159,16 +137,16 @@ class HiddenDiscrepancyServiceTest {
         .build();
 
     when(hiddenDiscrepancyRepository
-        .findByGmcReferenceNumberInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
-        .thenReturn(List.of(entity("GMC1"))) // alreadyHidden
-        .thenReturn(List.of(entity("GMC1"), entity("GMC2"), entity("GMC3"))); // nowHidden
+        .findByGmcIdInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
+        .thenReturn(List.of(entity("GMC1")));
+    when(hiddenDiscrepancyRepository.saveAll(anyList()))
+        .thenReturn(List.of(entity("GMC2"), entity("GMC3"))); // nowHidden
 
     mockMapperToReturnRealEntity();
 
-    // capture saveAll payload
     HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
 
-    assertResponseListCounts(response, 3, 1, 2, 0);
+    assertResponseListCounts(response, 1, 2, 0);
     assertResponseLists(response, List.of("GMC2", "GMC3"), List.of(), List.of("GMC1"));
 
     verify(hiddenDiscrepancyRepository).saveAll(saveCaptor.capture());
@@ -185,8 +163,9 @@ class HiddenDiscrepancyServiceTest {
   @Test
   void shouldContinueAndReturnListsComputedFromDbWhenSaveAllThrowsException() {
     when(hiddenDiscrepancyRepository
-        .findByGmcReferenceNumberInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
-        .thenReturn(List.of())                // alreadyHidden
+        .findByGmcIdInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
+        .thenReturn(List.of());
+    when(hiddenDiscrepancyRepository.saveAll(saveCaptor.capture()))
         .thenReturn(List.of(entity("GMC1"))); // nowHidden only has GMC1
 
     mockMapperToReturnRealEntity();
@@ -201,10 +180,11 @@ class HiddenDiscrepancyServiceTest {
 
     HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
 
-    assertResponseListCounts(response, 2, 0, 1, 1);
+    assertResponseListCounts(response, 0, 1, 1);
     assertResponseLists(response, List.of("GMC1"), List.of("GMC2"), List.of());
 
-    verify(hiddenDiscrepancyRepository).saveAll(anyList());
+    verify(hiddenDiscrepancyRepository).saveAll(saveCaptor.capture());
+    assertSavedEntities(saveCaptor.getValue(), Set.of("GMC1", "GMC2"), dto);
   }
 
   @Test
@@ -217,15 +197,16 @@ class HiddenDiscrepancyServiceTest {
         .build();
 
     when(hiddenDiscrepancyRepository
-        .findByGmcReferenceNumberInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
-        .thenReturn(List.of()) // alreadyHidden
+        .findByGmcIdInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
+        .thenReturn(List.of());
+    when(hiddenDiscrepancyRepository.saveAll(anyList()))
         .thenReturn(List.of(entity("GMC1"), entity("GMC2"))); // nowHidden missing GMC3
 
     mockMapperToReturnRealEntity();
 
     HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
 
-    assertResponseListCounts(response, 3, 0, 2, 1);
+    assertResponseListCounts(response, 0, 2, 1);
     assertResponseLists(response, List.of("GMC1", "GMC2"), List.of("GMC3"), List.of()
     );
   }
@@ -241,23 +222,26 @@ class HiddenDiscrepancyServiceTest {
 
     // capture the gmcIds list passed into repository (to ensure distinct() is applied)
     when(hiddenDiscrepancyRepository
-        .findByGmcReferenceNumberInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
-        .thenReturn(List.of()) // alreadyHidden
-        .thenReturn(List.of(entity("GMC1"), entity("GMC2"))); // nowHidden
+        .findByGmcIdInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
+        .thenReturn(List.of());
+
+    when(hiddenDiscrepancyRepository.saveAll(anyList()))
+        .thenReturn(List.of(entity("GMC1"), entity("GMC2")));
 
     mockMapperToReturnRealEntity();
 
     HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
 
-    assertResponseListCounts(response, 2, 0, 2, 0);
+    assertResponseListCounts(response, 0, 2, 0);
     assertResponseLists(response, List.of("GMC1", "GMC2"), List.of(), List.of());
 
-    verify(hiddenDiscrepancyRepository, times(2))
-        .findByGmcReferenceNumberInAndHiddenForDesignatedBodyCode(gmcIdsCaptor.capture(), eq(DBC));
-
-    List<String> requestedGmcsAtFirstQuery = gmcIdsCaptor.getAllValues().get(0);
-    assertEquals(2, requestedGmcsAtFirstQuery.size());
+    verify(hiddenDiscrepancyRepository)
+        .findByGmcIdInAndHiddenForDesignatedBodyCode(gmcIdsCaptor.capture(), eq(DBC));
+    List<String> requestedGmcsAtFirstQuery = gmcIdsCaptor.getValue();
     assertListContainsExactlyIgnoringOrder(requestedGmcsAtFirstQuery, List.of("GMC1", "GMC2"));
+
+    verify(hiddenDiscrepancyRepository).saveAll(saveCaptor.capture());
+    assertSavedEntities(saveCaptor.getValue(), Set.of("GMC1", "GMC2"), dto);
 
     verify(hiddenDiscrepancyMapper, times(1)).toEntity(eq(dto), eq("GMC1"),
         any(LocalDateTime.class));
@@ -267,15 +251,20 @@ class HiddenDiscrepancyServiceTest {
 
   // -------------------- Helpers --------------------
 
-  private DoctorInfoDto doc(String gmc) {
+  private static DoctorInfoDto doc(String gmc) {
     DoctorInfoDto d = mock(DoctorInfoDto.class);
     when(d.getGmcId()).thenReturn(gmc);
     return d;
   }
 
-  // Simple entity builder for repository return values (only gmc is relevant for service logic)
-  private HiddenDiscrepancy entity(String gmc) {
-    return HiddenDiscrepancy.builder().gmcReferenceNumber(gmc).build();
+  /**
+   * Simple entity builder for repository return values (only gmcId is relevant for service logic)
+   *
+   * @param gmcId The GMC Number for the returned object
+   * @return The HiddenDiscrepancy
+   */
+  private HiddenDiscrepancy entity(String gmcId) {
+    return HiddenDiscrepancy.builder().gmcId(gmcId).build();
   }
 
   // Mock mapper to return a real entity based on the input dto and gmcId
@@ -288,7 +277,7 @@ class HiddenDiscrepancyServiceTest {
           LocalDateTime batchTime = inv.getArgument(2, LocalDateTime.class);
 
           return HiddenDiscrepancy.builder()
-              .gmcReferenceNumber(gmcId)
+              .gmcId(gmcId)
               .hiddenForDesignatedBodyCode(dto.getHiddenForDesignatedBodyCode())
               .hiddenBy(dto.getHiddenBy())
               .reason(dto.getReason())
@@ -297,28 +286,36 @@ class HiddenDiscrepancyServiceTest {
         });
   }
 
-  // Assert the counts in the response and that the lists are non-null (but not their contents)
-  private void assertResponseListCounts(
-      HideDiscrepancyResponseDto response,
-      int expectedRequested,
-      int expectedExisting,
-      int expectedSuccessful,
-      int expectedFailed) {
-
+  /**
+   * Assert the counts in the response and that the lists are non-null (but not their contents)
+   *
+   * @param response
+   * @param expectedExisting
+   * @param expectedSuccessful
+   * @param expectedFailed
+   */
+  private void assertResponseListCounts(HideDiscrepancyResponseDto response, int expectedExisting,
+      int expectedSuccessful, int expectedFailed) {
     assertNotNull(response);
-    assertEquals(HiddenDiscrepancyServiceTest.DBC, response.getHiddenForDesignatedBodyCode());
-
-    assertEquals(expectedRequested, response.getRequestedCount());
-    assertEquals(expectedExisting, response.getExistingHiddenCount());
-    assertEquals(expectedSuccessful, response.getSuccessfulCount());
-    assertEquals(expectedFailed, response.getFailedCount());
-
     assertNotNull(response.getSuccessfulHiddenGmcIds());
     assertNotNull(response.getFailedToHideGmcIds());
     assertNotNull(response.getExistingHiddenGmcIds());
+    assertEquals(HiddenDiscrepancyServiceTest.DBC, response.getHiddenForDesignatedBodyCode());
+
+    assertEquals(expectedExisting, response.getExistingHiddenGmcIds().size());
+    assertEquals(expectedSuccessful, response.getSuccessfulHiddenGmcIds().size());
+    assertEquals(expectedFailed, response.getFailedToHideGmcIds().size());
+
   }
 
-  // Assert the contents of the three lists in the response (ignoring order)
+  /**
+   * Assert the contents of the three lists in the response (ignoring order)
+   *
+   * @param response
+   * @param expectedSuccessful
+   * @param expectedFailed
+   * @param expectedExisting
+   */
   private void assertResponseLists(HideDiscrepancyResponseDto response,
       List<String> expectedSuccessful,
       List<String> expectedFailed,
@@ -337,15 +334,21 @@ class HiddenDiscrepancyServiceTest {
     assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
   }
 
-  // Assert that the saved entities have the expected GMCs, correct mapping from dto,
-  // and consistent batchTime
+  /**
+   * Assert that the saved entities have the expected GMCs, correct mapping from dto and consistent
+   * batchTime
+   *
+   * @param saved
+   * @param expectedGmcs
+   * @param dto
+   */
   private void assertSavedEntities(List<HiddenDiscrepancy> saved, Set<String> expectedGmcs,
       HideDiscrepancyDto dto) {
     assertNotNull(saved);
     assertEquals(expectedGmcs.size(), saved.size());
 
     Set<String> savedGmcs = saved.stream()
-        .map(HiddenDiscrepancy::getGmcReferenceNumber)
+        .map(HiddenDiscrepancy::getGmcId)
         .collect(Collectors.toSet());
     assertEquals(expectedGmcs, savedGmcs);
 

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
@@ -160,33 +160,6 @@ class HiddenDiscrepancyServiceTest {
   }
 
   @Test
-  void shouldContinueAndReturnListsComputedFromDbWhenSaveAllThrowsException() {
-    when(hiddenDiscrepancyRepository
-        .findByGmcIdInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
-        .thenReturn(List.of());
-    when(hiddenDiscrepancyRepository.saveAll(saveCaptor.capture()))
-        .thenReturn(List.of(entity("GMC1"))).thenThrow(new RuntimeException("db down"));
-    // nowHidden only has GMC1
-
-    mockMapperToReturnRealEntity();
-
-    final HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
-        .hiddenForDesignatedBodyCode(DBC)
-        .hiddenBy(HIDDEN_BY)
-        .reason(REASON)
-        .doctors(List.of(doc("GMC1"), doc("GMC2")))
-        .build();
-
-    HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
-
-    assertResponseListCounts(response, 0, 1, 1);
-    assertResponseLists(response, List.of("GMC1"), List.of("GMC2"), List.of());
-
-    verify(hiddenDiscrepancyRepository).saveAll(saveCaptor.capture());
-    assertSavedEntities(saveCaptor.getValue(), Set.of("GMC1", "GMC2"), dto);
-  }
-
-  @Test
   void shouldReturnFailedListWhenDbDoesNotReturnAllAsHiddenAfterSaveAttempt() {
     final HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
         .hiddenForDesignatedBodyCode(DBC)

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
@@ -166,10 +166,10 @@ class HiddenDiscrepancyServiceTest {
         .findByGmcIdInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
         .thenReturn(List.of());
     when(hiddenDiscrepancyRepository.saveAll(saveCaptor.capture()))
-        .thenReturn(List.of(entity("GMC1"))); // nowHidden only has GMC1
+        .thenReturn(List.of(entity("GMC1"))).thenThrow(new RuntimeException("db down"));
+    // nowHidden only has GMC1
 
     mockMapperToReturnRealEntity();
-    doThrow(new RuntimeException("db down")).when(hiddenDiscrepancyRepository).saveAll(anyList());
 
     HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
         .hiddenForDesignatedBodyCode(DBC)

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2026 Crown Copyright (Health Education England)
+ * Copyright 2026 Crown Copyright (NHS England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,


### PR DESCRIPTION
After saveAll to bulk hide discrepancies, an extra query will be sent to db to check if all records are saved. 

Request body is like: 
```
{
    "hiddenForDesignatedBodyCode": "AAAA",
    "doctors": [
        {"gmcId": "11111111"}
    ],
    "hiddenBy": "admin",
    "reason": "test"
}
```

Response body is like: 
```
{
    "hiddenForDesignatedBodyCode": "AAAA",
    "requestedCount": 1,
    "existingHiddenCount": 0,
    "successfulCount": 1,
    "failedCount": 0,
    "successfulHiddenGmcIds": [
        "11111111"
    ],
    "failedToHideGmcIds": [],
    "existingHiddenGmcIds": []
}
```