### PR TITLE
Refactor/hide discrepancies to accept multiple dbcs tis21 8285

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.revalidation"
-version = "0.9.0"
+version = "0.10.0"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/HideDiscrepancyDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/HideDiscrepancyDto.java
@@ -40,8 +40,8 @@ import lombok.NoArgsConstructor;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class HideDiscrepancyDto {
 
-  @NotBlank(message = "Hidden For Designated Body Code must not be blank")
-  private String hiddenForDesignatedBodyCode;
+  @NotEmpty
+  private List<String> adminDesignatedBodyCodes;
   @NotEmpty
   private List<DoctorInfoDto> doctors;
   @NotBlank(message = "The user hiding discrepancies must be provided.")

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/HideDiscrepancyResponseDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/HideDiscrepancyResponseDto.java
@@ -21,7 +21,7 @@
 
 package uk.nhs.hee.tis.revalidation.connection.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -36,15 +36,32 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class HideDiscrepancyResponseDto {
 
-  private String hiddenForDesignatedBodyCode;
+  @Builder.Default
+  private List<HideDiscrepancyResponseItem> results = new ArrayList<>();
 
-  @Builder.Default
-  private List<String> successfulHiddenGmcIds = new ArrayList<>();
-  @Builder.Default
-  private List<String> failedToHideGmcIds = new ArrayList<>();
-  @Builder.Default
-  private List<String> existingHiddenGmcIds = new ArrayList<>();
+  /**
+   * A nested DTO class that contains the GMC ID and lists of successful, failed, and existing
+   * designated body codes for each doctor when hiding discrepancies.
+   */
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  public static class HideDiscrepancyResponseItem {
+
+    private String gmcId;
+
+    @Builder.Default
+    private List<String> successfulDbcCodes = new ArrayList<>();
+
+    @Builder.Default
+    private List<String> failedDbcCodes = new ArrayList<>();
+
+    @Builder.Default
+    private List<String> existingDbcCodes = new ArrayList<>();
+  }
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/HideDiscrepancyResponseDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/dto/HideDiscrepancyResponseDto.java
@@ -40,7 +40,7 @@ import lombok.NoArgsConstructor;
 public class HideDiscrepancyResponseDto {
 
   @Builder.Default
-  private List<HideDiscrepancyResponseItem> results = new ArrayList<>();
+  private List<HiddenDiscrepancyResponseItem> results = new ArrayList<>();
 
   /**
    * A nested DTO class that contains the GMC ID and lists of successful, failed, and existing
@@ -51,7 +51,7 @@ public class HideDiscrepancyResponseDto {
   @NoArgsConstructor
   @AllArgsConstructor
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
-  public static class HideDiscrepancyResponseItem {
+  public static class HiddenDiscrepancyResponseItem {
 
     private String gmcId;
 

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapper.java
@@ -44,5 +44,7 @@ public interface HiddenDiscrepancyMapper {
    */
   @Mapping(target = "id", ignore = true)
   @Mapping(target = "hiddenDateTime", source = "batchTime")
-  HiddenDiscrepancy toEntity(HideDiscrepancyDto dto, String gmcId, LocalDateTime batchTime);
+  @Mapping(target = "hiddenForDesignatedBodyCode", source = "hiddenForDesignatedBodyCode")
+  HiddenDiscrepancy toEntity(HideDiscrepancyDto dto, String gmcId, LocalDateTime batchTime,
+      String hiddenForDesignatedBodyCode);
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapper.java
@@ -37,11 +37,11 @@ public interface HiddenDiscrepancyMapper {
   /**
    * Maps a HideDiscrepancyDto to a HiddenDiscrepancy entity.
    *
-   * @param dto the HideDiscrepancyDto to be mapped
-   * @param gmcId the GMC ID of the doctor associated with the discrepancy
-   * @param batchTime the time when the discrepancy was hidden
+   * @param dto the HideDiscrepancyDto containing the data to be mapped
+   * @param gmcId the GMC ID of the doctor for whom the discrepancy is being hidden
+   * @param batchTime the timestamp when the hiding action is performed
    * @param hiddenForDesignatedBodyCode the designated body code for which the discrepancy is hidden
-   * @return a HiddenDiscrepancy entity mapped from the provided DTO and additional parameters
+   * @return a HiddenDiscrepancy entity populated with data from the DTO and additional parameters
    */
   @Mapping(target = "id", ignore = true)
   @Mapping(target = "hiddenDateTime", source = "batchTime")

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapper.java
@@ -37,10 +37,11 @@ public interface HiddenDiscrepancyMapper {
   /**
    * Maps a HideDiscrepancyDto to a HiddenDiscrepancy entity.
    *
-   * @param dto the HideDiscrepancyDto containing the data to be mapped
-   * @param gmcId the GMC ID of the doctor for whom the discrepancy is being hidden
-   * @param batchTime the timestamp when the hiding action is performed
-   * @return a HiddenDiscrepancy entity populated with data from the DTO and additional parameters
+   * @param dto the HideDiscrepancyDto to be mapped
+   * @param gmcId the GMC ID of the doctor associated with the discrepancy
+   * @param batchTime the time when the discrepancy was hidden
+   * @param hiddenForDesignatedBodyCode the designated body code for which the discrepancy is hidden
+   * @return a HiddenDiscrepancy entity mapped from the provided DTO and additional parameters
    */
   @Mapping(target = "id", ignore = true)
   @Mapping(target = "hiddenDateTime", source = "batchTime")

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/repository/HiddenDiscrepancyRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/repository/HiddenDiscrepancyRepository.java
@@ -36,7 +36,7 @@ public interface HiddenDiscrepancyRepository extends MongoRepository<HiddenDiscr
    * Finds hidden discrepancies by GMC reference numbers and designated body code.
    *
    * @param gmcReferenceNumbers         the list of GMC reference numbers to search for
-   * @param hiddenForDesignatedBodyCodes the list of designated body cods for which the
+   * @param hiddenForDesignatedBodyCodes the list of designated body codes for which the
    *                                     discrepancies are hidden
    * @return a list of HiddenDiscrepancy entities matching the criteria
    */

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/repository/HiddenDiscrepancyRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/repository/HiddenDiscrepancyRepository.java
@@ -36,12 +36,12 @@ public interface HiddenDiscrepancyRepository extends MongoRepository<HiddenDiscr
    * Finds hidden discrepancies by GMC reference numbers and designated body code.
    *
    * @param gmcReferenceNumbers         the list of GMC reference numbers to search for
-   * @param hiddenForDesignatedBodyCode the designated body code for which the discrepancies are
-   *                                    hidden
+   * @param hiddenForDesignatedBodyCodes the list of designated body cods for which the
+   *                                     discrepancies are hidden
    * @return a list of HiddenDiscrepancy entities matching the criteria
    */
-  List<HiddenDiscrepancy> findByGmcIdInAndHiddenForDesignatedBodyCode(
+  List<HiddenDiscrepancy> findByGmcIdInAndHiddenForDesignatedBodyCodeIn(
       List<String> gmcReferenceNumbers,
-      String hiddenForDesignatedBodyCode
+      List<String> hiddenForDesignatedBodyCodes
   );
 }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
@@ -123,9 +123,11 @@ public class HiddenDiscrepancyService {
     var map = new HashMap<String, HideDiscrepancyResponseDto.HideDiscrepancyResponseItem>();
     for (DoctorInfoDto doctor : doctors) {
       String gmcId = doctor.getGmcId();
-      var item = new HideDiscrepancyResponseDto.HideDiscrepancyResponseItem();
-      item.setGmcId(gmcId);
-      map.put(gmcId, item);
+      if (gmcId != null) {
+        var item = new HideDiscrepancyResponseDto.HideDiscrepancyResponseItem();
+        item.setGmcId(gmcId);
+        map.put(gmcId, item);
+      }
     }
     return map;
   }
@@ -136,24 +138,23 @@ public class HiddenDiscrepancyService {
 
     for (DoctorInfoDto doctor : doctors) {
       String gmcId = doctor.getGmcId();
+      if (gmcId != null) {
+        Set<String> doctorDbcs = Stream.of(doctor.getCurrentDesignatedBodyCode(),
+                doctor.getProgrammeOwnerDesignatedBodyCode())
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
 
-      Set<String> doctorDbcs = Stream.of(doctor.getCurrentDesignatedBodyCode(),
-              doctor.getProgrammeOwnerDesignatedBodyCode())
-          .filter(Objects::nonNull)
-          .collect(Collectors.toSet());
+        List<String> toHideList = adminDesignatedBodyCodes.stream()
+            .filter(doctorDbcs::contains)
+            .distinct()
+            .collect(Collectors.toList());
 
-      List<String> toHideList = adminDesignatedBodyCodes.stream()
-          .filter(doctorDbcs::contains)
-          .distinct()
-          .collect(Collectors.toList());
-
-      if (toHideList.isEmpty()) {
-        continue;
+        if (!toHideList.isEmpty()) {
+          toHideByGmc.put(gmcId, toHideList);
+          allGmcIds.add(gmcId);
+          allDbcs.addAll(toHideList);
+        }
       }
-
-      toHideByGmc.put(gmcId, toHideList);
-      allGmcIds.add(gmcId);
-      allDbcs.addAll(toHideList);
     }
   }
 

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
@@ -21,15 +21,15 @@
 
 package uk.nhs.hee.tis.revalidation.connection.service;
 
-import static java.util.function.Predicate.not;
 import static org.springframework.data.domain.PageRequest.of;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
@@ -81,40 +81,88 @@ public class HiddenDiscrepancyService {
    * @return a response DTO summarizing the results of the hide operation
    */
   public HideDiscrepancyResponseDto hideDiscrepancies(HideDiscrepancyDto dto) {
-    final String hiddenForDbc = dto.getHiddenForDesignatedBodyCode();
-    final List<String> requestedGmcIds = extractRequestedGmcIds(dto);
+    HideDiscrepancyResponseDto response = new HideDiscrepancyResponseDto();
 
-    if (requestedGmcIds.isEmpty()) {
-      return HideDiscrepancyResponseDto.builder().hiddenForDesignatedBodyCode(hiddenForDbc).build();
-    }
+    var adminDbcs = dto.getAdminDesignatedBodyCodes();
 
-    final Set<String> alreadyHidden = findHiddenGmcIds(requestedGmcIds, hiddenForDbc);
-    final List<String> newGmcIdsToHide = requestedGmcIds.stream()
-        .filter(not(alreadyHidden::contains))
-        .collect(Collectors.toList());
-    if (!alreadyHidden.isEmpty()) {
-      log.warn("Discrepancies for the following GMC IDs are already hidden for {}: {}",
-          hiddenForDbc, alreadyHidden);
-    }
-    final List<String> savedGmcIds = new ArrayList<>();
+    for (DoctorInfoDto doctor : dto.getDoctors()) {
+      var item = new HideDiscrepancyResponseDto.HideDiscrepancyResponseItem();
+      String gmcId = doctor.getGmcId();
+      item.setGmcId(gmcId);
 
-    if (!newGmcIdsToHide.isEmpty()) {
-      final LocalDateTime batchTime = LocalDateTime.now();
-      final List<HiddenDiscrepancy> newEntities = newGmcIdsToHide.stream()
-          .map(gmcId -> hiddenDiscrepancyMapper.toEntity(dto, gmcId, batchTime))
+      // collect the doctor's designated body codes (may be null)
+      var doctorDbcs = Stream.of(doctor.getCurrentDesignatedBodyCode(),
+              doctor.getProgrammeOwnerDesignatedBodyCode())
+          .filter(Objects::nonNull)
+          .collect(Collectors.toSet());
+
+      // intersection with admin codes
+      var toHide = adminDbcs.stream()
+          .filter(doctorDbcs::contains)
+          .distinct()
           .collect(Collectors.toList());
 
-      savedGmcIds.addAll(hiddenDiscrepancyRepository.saveAll(newEntities).stream()
-          .map(HiddenDiscrepancy::getGmcId)
-          .collect(Collectors.toList()));
+      if (toHide.isEmpty()) {
+        // nothing to hide for this doctor
+        response.getResults().add(item);
+        continue;
+      }
+
+      for (String dbc : toHide) {
+        try {
+          // check existence
+          var existing = hiddenDiscrepancyRepository
+              .findByGmcIdInAndHiddenForDesignatedBodyCodeIn(List.of(gmcId), List.of(dbc));
+          if (existing != null && !existing.isEmpty()) {
+            mergeExisting(item, dbc);
+            continue;
+          }
+
+          var entity = hiddenDiscrepancyMapper.toEntity(dto, gmcId, LocalDateTime.now(), dbc);
+          entity.setHiddenBy(dto.getHiddenBy());
+          entity.setReason(dto.getReason());
+          hiddenDiscrepancyRepository.save(entity);
+          mergeSuccessful(item, dbc);
+        } catch (Exception ex) {
+          log.error("Failed to hide discrepancy for gmcId {} and dbc {}: {}", gmcId, dbc,
+              ex.getMessage());
+          mergeFailed(item, dbc);
+        }
+      }
+
+      response.getResults().add(item);
     }
 
-    final List<String> failedToHide = newGmcIdsToHide.stream()
-        .filter(not(savedGmcIds::contains))
-        .collect(Collectors.toList());
+    return response;
+  }
+  private void mergeSuccessful(HideDiscrepancyResponseDto.HideDiscrepancyResponseItem item,
+      String dbc) {
+    var list = item.getSuccessfulDbcCodes();
+    if (list == null) {
+      list = new ArrayList<>();
+      item.setSuccessfulDbcCodes(list);
+    }
+    list.add(dbc);
+  }
 
-    return new HideDiscrepancyResponseDto(hiddenForDbc, savedGmcIds, failedToHide,
-        new ArrayList<>(alreadyHidden));
+  private void mergeFailed(HideDiscrepancyResponseDto.HideDiscrepancyResponseItem item,
+      String dbc) {
+    var list = item.getFailedDbcCodes();
+    if (list == null) {
+      list = new ArrayList<>();
+      item.setFailedDbcCodes(list);
+    }
+    list.add(dbc);
+  }
+
+  private void mergeExisting(HideDiscrepancyResponseDto.HideDiscrepancyResponseItem item,
+      String dbc) {
+    var list = item.getExistingDbcCodes();
+    if (list == null) {
+      list = new ArrayList<>();
+      item.setExistingDbcCodes(list);
+    }
+    list.add(dbc);
   }
 
   /**
@@ -147,7 +195,8 @@ public class HiddenDiscrepancyService {
 
   private Set<String> findHiddenGmcIds(List<String> gmcIds, String hiddenForDbc) {
     return hiddenDiscrepancyRepository
-        .findByGmcIdInAndHiddenForDesignatedBodyCode(gmcIds, hiddenForDbc).stream()
+        .findByGmcIdInAndHiddenForDesignatedBodyCodeIn(gmcIds,
+            List.of(hiddenForDbc)).stream()
         .map(HiddenDiscrepancy::getGmcId)
         .collect(Collectors.toSet());
   }

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
@@ -41,6 +41,7 @@ import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.revalidation.connection.dto.DoctorInfoDto;
 import uk.nhs.hee.tis.revalidation.connection.dto.HideDiscrepancyDto;
 import uk.nhs.hee.tis.revalidation.connection.dto.HideDiscrepancyResponseDto;
+import uk.nhs.hee.tis.revalidation.connection.dto.HideDiscrepancyResponseDto.HiddenDiscrepancyResponseItem;
 import uk.nhs.hee.tis.revalidation.connection.entity.HiddenDiscrepancy;
 import uk.nhs.hee.tis.revalidation.connection.mapper.HiddenDiscrepancyMapper;
 import uk.nhs.hee.tis.revalidation.connection.message.payloads.IndexSyncMessage;
@@ -118,13 +119,13 @@ public class HiddenDiscrepancyService {
   }
 
   // Prepare a map of GMC ID to response item for easy lookup and result aggregation
-  private Map<String, HideDiscrepancyResponseDto.HideDiscrepancyResponseItem> prepareResponseItemsMap(
+  private Map<String, HiddenDiscrepancyResponseItem> prepareResponseItemsMap(
       List<DoctorInfoDto> doctors) {
-    var map = new HashMap<String, HideDiscrepancyResponseDto.HideDiscrepancyResponseItem>();
+    var map = new HashMap<String, HiddenDiscrepancyResponseItem>();
     for (DoctorInfoDto doctor : doctors) {
       String gmcId = doctor.getGmcId();
       if (gmcId != null) {
-        var item = new HideDiscrepancyResponseDto.HideDiscrepancyResponseItem();
+        var item = new HiddenDiscrepancyResponseItem();
         item.setGmcId(gmcId);
         map.put(gmcId, item);
       }
@@ -158,7 +159,7 @@ public class HiddenDiscrepancyService {
     }
   }
 
-  // Query existing hidden discrepancies for the given GMC IDs and designated body codes to avoid duplicates
+  // Query existing hidden discrepancies for the given GMC IDs and designated body codes
   private Set<String> queryExistingPairs(Set<String> allGmcIds, Set<String> allDbcs) {
     if (allGmcIds.isEmpty() || allDbcs.isEmpty()) {
       return Set.of();
@@ -173,7 +174,7 @@ public class HiddenDiscrepancyService {
 
   private List<HiddenDiscrepancy> buildEntitiesToSave(HideDiscrepancyDto dto,
       Map<String, List<String>> toHideByGmc, Set<String> existingPairs,
-      Map<String, HideDiscrepancyResponseDto.HideDiscrepancyResponseItem> responseItems) {
+      Map<String, HiddenDiscrepancyResponseItem> responseItems) {
     List<HiddenDiscrepancy> toSave = new ArrayList<>();
     LocalDateTime saveTime = LocalDateTime.now();
     for (Map.Entry<String, List<String>> entry : toHideByGmc.entrySet()) {
@@ -197,7 +198,7 @@ public class HiddenDiscrepancyService {
   }
 
   private void saveEntitiesBatch(List<HiddenDiscrepancy> toSave,
-      Map<String, HideDiscrepancyResponseDto.HideDiscrepancyResponseItem> responseItems) {
+      Map<String, HiddenDiscrepancyResponseItem> responseItems) {
     if (toSave.isEmpty()) {
       return;
     }
@@ -221,7 +222,7 @@ public class HiddenDiscrepancyService {
     }
   }
 
-  private void mergeSuccessful(HideDiscrepancyResponseDto.HideDiscrepancyResponseItem item,
+  private void mergeSuccessful(HiddenDiscrepancyResponseItem item,
       String dbc) {
     var list = item.getSuccessfulDbcCodes();
     if (list == null) {
@@ -231,7 +232,7 @@ public class HiddenDiscrepancyService {
     list.add(dbc);
   }
 
-  private void mergeFailed(HideDiscrepancyResponseDto.HideDiscrepancyResponseItem item,
+  private void mergeFailed(HiddenDiscrepancyResponseItem item,
       String dbc) {
     var list = item.getFailedDbcCodes();
     if (list == null) {
@@ -241,7 +242,7 @@ public class HiddenDiscrepancyService {
     list.add(dbc);
   }
 
-  private void mergeExisting(HideDiscrepancyResponseDto.HideDiscrepancyResponseItem item,
+  private void mergeExisting(HiddenDiscrepancyResponseItem item,
       String dbc) {
     var list = item.getExistingDbcCodes();
     if (list == null) {

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
@@ -24,8 +24,11 @@ package uk.nhs.hee.tis.revalidation.connection.service;
 import static org.springframework.data.domain.PageRequest.of;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -81,60 +84,101 @@ public class HiddenDiscrepancyService {
    * @return a response DTO summarizing the results of the hide operation
    */
   public HideDiscrepancyResponseDto hideDiscrepancies(HideDiscrepancyDto dto) {
+
     HideDiscrepancyResponseDto response = new HideDiscrepancyResponseDto();
 
-    var adminDbcs = dto.getAdminDesignatedBodyCodes();
+    var adminDesignatedBodyCodes = dto.getAdminDesignatedBodyCodes();
+
+    // Prepare per-doctor toHide lists and response items
+    Map<String, HideDiscrepancyResponseDto.HideDiscrepancyResponseItem> responseItems =
+        new HashMap<>();
+    Map<String, List<String>> toHideByGmc = new HashMap<>();
+    Set<String> allGmcIds = new HashSet<>();
+    Set<String> allDbcs = new HashSet<>();
 
     for (DoctorInfoDto doctor : dto.getDoctors()) {
-      var item = new HideDiscrepancyResponseDto.HideDiscrepancyResponseItem();
       String gmcId = doctor.getGmcId();
+      var item = new HideDiscrepancyResponseDto.HideDiscrepancyResponseItem();
       item.setGmcId(gmcId);
+      responseItems.put(gmcId, item);
 
-      // collect the doctor's designated body codes (may be null)
+      // collect the doctor's designated body codes
       var doctorDbcs = Stream.of(doctor.getCurrentDesignatedBodyCode(),
               doctor.getProgrammeOwnerDesignatedBodyCode())
           .filter(Objects::nonNull)
           .collect(Collectors.toSet());
 
       // intersection with admin codes
-      var toHide = adminDbcs.stream()
+      var toHide = adminDesignatedBodyCodes.stream()
           .filter(doctorDbcs::contains)
           .distinct()
           .collect(Collectors.toList());
 
       if (toHide.isEmpty()) {
         // nothing to hide for this doctor
-        response.getResults().add(item);
         continue;
       }
 
-      for (String dbc : toHide) {
-        try {
-          // check existence
-          var existing = hiddenDiscrepancyRepository
-              .findByGmcIdInAndHiddenForDesignatedBodyCodeIn(List.of(gmcId), List.of(dbc));
-          if (existing != null && !existing.isEmpty()) {
-            mergeExisting(item, dbc);
-            continue;
-          }
+      toHideByGmc.put(gmcId, toHide);
+      allGmcIds.add(gmcId);
+      allDbcs.addAll(toHide);
+    }
 
+    if (toHideByGmc.isEmpty()) {
+      // nothing to do
+      response.getResults().addAll(responseItems.values());
+      return response;
+    }
+
+    // Query existing hidden discrepancies for all relevant gmcs and dbcs
+    var existing = hiddenDiscrepancyRepository
+        .findByGmcIdInAndHiddenForDesignatedBodyCodeIn(new ArrayList<>(allGmcIds),
+            new ArrayList<>(allDbcs));
+    Set<String> existingPairs = existing.stream()
+        .map(e -> e.getGmcId() + "#" + e.getHiddenForDesignatedBodyCode())
+        .collect(Collectors.toSet());
+
+    // Build list of entities to save (non-existing pairs)
+    List<HiddenDiscrepancy> toSave = new ArrayList<>();
+    for (Map.Entry<String, List<String>> entry : toHideByGmc.entrySet()) {
+      String gmcId = entry.getKey();
+      var item = responseItems.get(gmcId);
+      for (String dbc : entry.getValue()) {
+        String key = gmcId + "#" + dbc;
+        if (existingPairs.contains(key)) {
+          mergeExisting(item, dbc);
+        } else {
           var entity = hiddenDiscrepancyMapper.toEntity(dto, gmcId, LocalDateTime.now(), dbc);
           entity.setHiddenBy(dto.getHiddenBy());
           entity.setReason(dto.getReason());
-          hiddenDiscrepancyRepository.save(entity);
-          mergeSuccessful(item, dbc);
-        } catch (Exception ex) {
-          log.error("Failed to hide discrepancy for gmcId {} and dbc {}: {}", gmcId, dbc,
-              ex.getMessage());
-          mergeFailed(item, dbc);
+          toSave.add(entity);
         }
       }
-
-      response.getResults().add(item);
     }
+
+    // Save all new entities in batch, with fallback for duplicate-key concurrency
+    if (!toSave.isEmpty()) {
+      try {
+        var saved = hiddenDiscrepancyRepository.saveAll(toSave);
+        for (HiddenDiscrepancy s : saved) {
+          var item = responseItems.get(s.getGmcId());
+          mergeSuccessful(item, s.getHiddenForDesignatedBodyCode());
+        }
+      } catch (Exception ex) {
+        // If batch save failed, mark all as failed
+        for (HiddenDiscrepancy e : toSave) {
+          mergeFailed(responseItems.get(e.getGmcId()), e.getHiddenForDesignatedBodyCode());
+        }
+        log.error("Batch save failed: {}", ex.getMessage());
+      }
+    }
+
+    // Add all response items
+    response.getResults().addAll(responseItems.values());
 
     return response;
   }
+
   private void mergeSuccessful(HideDiscrepancyResponseDto.HideDiscrepancyResponseItem item,
       String dbc) {
     var list = item.getSuccessfulDbcCodes();

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
@@ -38,6 +38,8 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 import uk.nhs.hee.tis.revalidation.connection.dto.DoctorInfoDto;
 import uk.nhs.hee.tis.revalidation.connection.dto.HiddenDiscrepancyDto;
 import uk.nhs.hee.tis.revalidation.connection.dto.HideDiscrepancyDto;
@@ -95,11 +97,8 @@ public class HiddenDiscrepancyService {
   public HideDiscrepancyResponseDto hideDiscrepancies(HideDiscrepancyDto dto) {
     HideDiscrepancyResponseDto response = new HideDiscrepancyResponseDto();
 
-    if (dto == null || dto.getDoctors() == null || dto.getDoctors().isEmpty()
-        || dto.getAdminDesignatedBodyCodes() == null || dto.getAdminDesignatedBodyCodes()
-        .isEmpty()) {
-      return response;
-    }
+    // Fail fast. Service-side defensive validation
+    validateHideDiscrepancyInput(dto);
 
     List<String> adminDesignatedBodyCodes = dto.getAdminDesignatedBodyCodes();
 
@@ -126,13 +125,23 @@ public class HiddenDiscrepancyService {
     return response;
   }
 
+  private void validateHideDiscrepancyInput(HideDiscrepancyDto dto) {
+    Objects.requireNonNull(dto, "HideDiscrepancyDto must not be null");
+    if (CollectionUtils.isEmpty(dto.getAdminDesignatedBodyCodes())) {
+      throw new IllegalArgumentException("adminDesignatedBodyCodes must not be empty");
+    }
+    if (CollectionUtils.isEmpty(dto.getDoctors())) {
+      throw new IllegalArgumentException("doctors must not be empty");
+    }
+  }
+
   // Prepare a map of GMC ID to response item for easy lookup and result aggregation
   private Map<String, HiddenDiscrepancyResponseItem> prepareResponseItemsMap(
       List<DoctorInfoDto> doctors) {
     var map = new HashMap<String, HiddenDiscrepancyResponseItem>();
     for (DoctorInfoDto doctor : doctors) {
       String gmcId = doctor.getGmcId();
-      if (gmcId != null) {
+      if (StringUtils.hasText(gmcId)) {
         var item = new HiddenDiscrepancyResponseItem();
         item.setGmcId(gmcId);
         map.put(gmcId, item);

--- a/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyService.java
@@ -24,10 +24,10 @@ package uk.nhs.hee.tis.revalidation.connection.service;
 import static org.springframework.data.domain.PageRequest.of;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -84,99 +84,140 @@ public class HiddenDiscrepancyService {
    * @return a response DTO summarizing the results of the hide operation
    */
   public HideDiscrepancyResponseDto hideDiscrepancies(HideDiscrepancyDto dto) {
-
     HideDiscrepancyResponseDto response = new HideDiscrepancyResponseDto();
 
-    var adminDesignatedBodyCodes = dto.getAdminDesignatedBodyCodes();
+    if (dto == null || dto.getDoctors() == null || dto.getDoctors().isEmpty()
+        || dto.getAdminDesignatedBodyCodes() == null || dto.getAdminDesignatedBodyCodes()
+        .isEmpty()) {
+      return response;
+    }
 
-    // Prepare per-doctor toHide lists and response items
-    Map<String, HideDiscrepancyResponseDto.HideDiscrepancyResponseItem> responseItems =
-        new HashMap<>();
+    List<String> adminDesignatedBodyCodes = dto.getAdminDesignatedBodyCodes();
+
+    var responseItemsMap = prepareResponseItemsMap(dto.getDoctors());
+
     Map<String, List<String>> toHideByGmc = new HashMap<>();
     Set<String> allGmcIds = new HashSet<>();
     Set<String> allDbcs = new HashSet<>();
+    prepareToHideData(dto.getDoctors(), adminDesignatedBodyCodes, toHideByGmc, allGmcIds, allDbcs);
 
-    for (DoctorInfoDto doctor : dto.getDoctors()) {
+    if (toHideByGmc.isEmpty()) {
+      response.getResults().addAll(responseItemsMap.values());
+      return response;
+    }
+
+    Set<String> existingPairs = queryExistingPairs(allGmcIds, allDbcs);
+
+    List<HiddenDiscrepancy> toSave = buildEntitiesToSave(dto, toHideByGmc, existingPairs,
+        responseItemsMap);
+
+    saveEntitiesBatch(toSave, responseItemsMap);
+
+    response.getResults().addAll(responseItemsMap.values());
+    return response;
+  }
+
+  // Prepare a map of GMC ID to response item for easy lookup and result aggregation
+  private Map<String, HideDiscrepancyResponseDto.HideDiscrepancyResponseItem> prepareResponseItemsMap(
+      List<DoctorInfoDto> doctors) {
+    var map = new HashMap<String, HideDiscrepancyResponseDto.HideDiscrepancyResponseItem>();
+    for (DoctorInfoDto doctor : doctors) {
       String gmcId = doctor.getGmcId();
       var item = new HideDiscrepancyResponseDto.HideDiscrepancyResponseItem();
       item.setGmcId(gmcId);
-      responseItems.put(gmcId, item);
+      map.put(gmcId, item);
+    }
+    return map;
+  }
 
-      // collect the doctor's designated body codes
-      var doctorDbcs = Stream.of(doctor.getCurrentDesignatedBodyCode(),
+  private void prepareToHideData(List<DoctorInfoDto> doctors,
+      List<String> adminDesignatedBodyCodes, Map<String, List<String>> toHideByGmc,
+      Set<String> allGmcIds, Set<String> allDbcs) {
+
+    for (DoctorInfoDto doctor : doctors) {
+      String gmcId = doctor.getGmcId();
+
+      Set<String> doctorDbcs = Stream.of(doctor.getCurrentDesignatedBodyCode(),
               doctor.getProgrammeOwnerDesignatedBodyCode())
           .filter(Objects::nonNull)
           .collect(Collectors.toSet());
 
-      // intersection with admin codes
-      var toHide = adminDesignatedBodyCodes.stream()
+      List<String> toHideList = adminDesignatedBodyCodes.stream()
           .filter(doctorDbcs::contains)
           .distinct()
           .collect(Collectors.toList());
 
-      if (toHide.isEmpty()) {
-        // nothing to hide for this doctor
+      if (toHideList.isEmpty()) {
         continue;
       }
 
-      toHideByGmc.put(gmcId, toHide);
+      toHideByGmc.put(gmcId, toHideList);
       allGmcIds.add(gmcId);
-      allDbcs.addAll(toHide);
+      allDbcs.addAll(toHideList);
     }
+  }
 
-    if (toHideByGmc.isEmpty()) {
-      // nothing to do
-      response.getResults().addAll(responseItems.values());
-      return response;
+  // Query existing hidden discrepancies for the given GMC IDs and designated body codes to avoid duplicates
+  private Set<String> queryExistingPairs(Set<String> allGmcIds, Set<String> allDbcs) {
+    if (allGmcIds.isEmpty() || allDbcs.isEmpty()) {
+      return Set.of();
     }
-
-    // Query existing hidden discrepancies for all relevant gmcs and dbcs
-    var existing = hiddenDiscrepancyRepository
-        .findByGmcIdInAndHiddenForDesignatedBodyCodeIn(new ArrayList<>(allGmcIds),
-            new ArrayList<>(allDbcs));
-    Set<String> existingPairs = existing.stream()
-        .map(e -> e.getGmcId() + "#" + e.getHiddenForDesignatedBodyCode())
+    var existing = hiddenDiscrepancyRepository.findByGmcIdInAndHiddenForDesignatedBodyCodeIn(
+        new ArrayList<>(allGmcIds), new ArrayList<>(allDbcs));
+    // Create a set of "GMCID#DBC" strings for easy lookup when building entities to save
+    return existing.stream()
+        .map(e -> buildKey(e.getGmcId(), e.getHiddenForDesignatedBodyCode()))
         .collect(Collectors.toSet());
+  }
 
-    // Build list of entities to save (non-existing pairs)
+  private List<HiddenDiscrepancy> buildEntitiesToSave(HideDiscrepancyDto dto,
+      Map<String, List<String>> toHideByGmc, Set<String> existingPairs,
+      Map<String, HideDiscrepancyResponseDto.HideDiscrepancyResponseItem> responseItems) {
     List<HiddenDiscrepancy> toSave = new ArrayList<>();
+    LocalDateTime saveTime = LocalDateTime.now();
     for (Map.Entry<String, List<String>> entry : toHideByGmc.entrySet()) {
       String gmcId = entry.getKey();
       var item = responseItems.get(gmcId);
       for (String dbc : entry.getValue()) {
-        String key = gmcId + "#" + dbc;
+        String key = buildKey(gmcId, dbc);
         if (existingPairs.contains(key)) {
           mergeExisting(item, dbc);
         } else {
-          var entity = hiddenDiscrepancyMapper.toEntity(dto, gmcId, LocalDateTime.now(), dbc);
-          entity.setHiddenBy(dto.getHiddenBy());
-          entity.setReason(dto.getReason());
+          var entity = hiddenDiscrepancyMapper.toEntity(dto, gmcId, saveTime, dbc);
           toSave.add(entity);
         }
       }
     }
+    return toSave;
+  }
 
-    // Save all new entities in batch, with fallback for duplicate-key concurrency
-    if (!toSave.isEmpty()) {
-      try {
-        var saved = hiddenDiscrepancyRepository.saveAll(toSave);
-        for (HiddenDiscrepancy s : saved) {
-          var item = responseItems.get(s.getGmcId());
-          mergeSuccessful(item, s.getHiddenForDesignatedBodyCode());
-        }
-      } catch (Exception ex) {
-        // If batch save failed, mark all as failed
-        for (HiddenDiscrepancy e : toSave) {
-          mergeFailed(responseItems.get(e.getGmcId()), e.getHiddenForDesignatedBodyCode());
-        }
-        log.error("Batch save failed: {}", ex.getMessage());
-      }
+  private String buildKey(String gmcId, String dbc) {
+    return gmcId + "#" + dbc;
+  }
+
+  private void saveEntitiesBatch(List<HiddenDiscrepancy> toSave,
+      Map<String, HideDiscrepancyResponseDto.HideDiscrepancyResponseItem> responseItems) {
+    if (toSave.isEmpty()) {
+      return;
+    }
+    var saved = hiddenDiscrepancyRepository.saveAll(toSave);
+    // build set of saved keys for comparison
+    var savedKeys = saved.stream()
+        .map(s -> buildKey(s.getGmcId(), s.getHiddenForDesignatedBodyCode()))
+        .collect(Collectors.toSet());
+
+    // mark all saved entries as successful
+    for (HiddenDiscrepancy hd : saved) {
+      mergeSuccessful(responseItems.get(hd.getGmcId()), hd.getHiddenForDesignatedBodyCode());
     }
 
-    // Add all response items
-    response.getResults().addAll(responseItems.values());
-
-    return response;
+    // any toSave element not present in savedKeys -> failed
+    for (HiddenDiscrepancy hd : toSave) {
+      String key = buildKey(hd.getGmcId(), hd.getHiddenForDesignatedBodyCode());
+      if (!savedKeys.contains(key)) {
+        mergeFailed(responseItems.get(hd.getGmcId()), hd.getHiddenForDesignatedBodyCode());
+      }
+    }
   }
 
   private void mergeSuccessful(HideDiscrepancyResponseDto.HideDiscrepancyResponseItem item,
@@ -224,25 +265,6 @@ public class HiddenDiscrepancyService {
               IllegalArgumentException("No hidden discrepancy found with id: " + discrepancyId);
         }
     );
-  }
-
-  private List<String> extractRequestedGmcIds(HideDiscrepancyDto dto) {
-    if (dto.getDoctors() == null) {
-      return List.of();
-    }
-    return dto.getDoctors().stream()
-        .map(DoctorInfoDto::getGmcId)
-        .filter(Objects::nonNull)
-        .distinct()
-        .collect(Collectors.toList());
-  }
-
-  private Set<String> findHiddenGmcIds(List<String> gmcIds, String hiddenForDbc) {
-    return hiddenDiscrepancyRepository
-        .findByGmcIdInAndHiddenForDesignatedBodyCodeIn(gmcIds,
-            List.of(hiddenForDbc)).stream()
-        .map(HiddenDiscrepancy::getGmcId)
-        .collect(Collectors.toSet());
   }
 
   /**

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionControllerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionControllerTest.java
@@ -415,11 +415,19 @@ class ConnectionControllerTest {
     return Stream.of(
         Arguments.of(
             HideDiscrepancyDto.builder()
+                .adminDesignatedBodyCodes(null)
+                .hiddenBy(ADMIN_NAME)
+                .doctors(validDoctors)
+                .build(),
+            "adminDesignatedBodyCodes list is null"
+        ),
+        Arguments.of(
+            HideDiscrepancyDto.builder()
                 .adminDesignatedBodyCodes(List.of())
                 .hiddenBy(ADMIN_NAME)
                 .doctors(validDoctors)
                 .build(),
-            "hiddenForDesignatedBodyCode is null"
+            "adminDesignatedBodyCode list is empty"
         ),
         Arguments.of(
             HideDiscrepancyDto.builder()
@@ -427,7 +435,7 @@ class ConnectionControllerTest {
                 .hiddenBy(ADMIN_NAME)
                 .doctors(null)
                 .build(),
-            "doctors is null"
+            "doctor list is null"
         ),
         Arguments.of(
             HideDiscrepancyDto.builder()
@@ -435,7 +443,7 @@ class ConnectionControllerTest {
                 .hiddenBy(ADMIN_NAME)
                 .doctors(List.of())
                 .build(),
-            "doctors is empty"
+            "doctor list is empty"
         ),
         Arguments.of(
             HideDiscrepancyDto.builder()

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionControllerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionControllerTest.java
@@ -64,6 +64,7 @@ import uk.nhs.hee.tis.revalidation.connection.dto.HiddenDiscrepancyInfoDto;
 import uk.nhs.hee.tis.revalidation.connection.dto.HiddenDiscrepancySummaryDto;
 import uk.nhs.hee.tis.revalidation.connection.dto.HideDiscrepancyDto;
 import uk.nhs.hee.tis.revalidation.connection.dto.HideDiscrepancyResponseDto;
+import uk.nhs.hee.tis.revalidation.connection.dto.HideDiscrepancyResponseDto.HiddenDiscrepancyResponseItem;
 import uk.nhs.hee.tis.revalidation.connection.dto.UpdateConnectionDto;
 import uk.nhs.hee.tis.revalidation.connection.dto.UpdateConnectionResponseDto;
 import uk.nhs.hee.tis.revalidation.connection.entity.ConnectionRequestType;
@@ -465,7 +466,7 @@ class ConnectionControllerTest {
         .adminDesignatedBodyCodes(List.of(DESIGNATED_BODY_CODES))
         .doctors(List.of(doctor)).hiddenBy(ADMIN_NAME).build();
 
-    var item = HideDiscrepancyResponseDto.HideDiscrepancyResponseItem.builder()
+    var item = HiddenDiscrepancyResponseItem.builder()
         .gmcId(gmcId)
         .successfulDbcCodes(List.of(designatedBodyCode))
         .build();

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionControllerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/controller/ConnectionControllerTest.java
@@ -140,7 +140,7 @@ class ConnectionControllerTest {
   private String hiddenReason;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     changeReason = faker.lorem().sentence();
     designatedBodyCode = faker.number().digits(8);
     gmcId = faker.number().digits(8);
@@ -413,7 +413,7 @@ class ConnectionControllerTest {
     return Stream.of(
         Arguments.of(
             HideDiscrepancyDto.builder()
-                .hiddenForDesignatedBodyCode(null)
+                .adminDesignatedBodyCodes(List.of())
                 .hiddenBy(ADMIN_NAME)
                 .doctors(validDoctors)
                 .build(),
@@ -421,15 +421,7 @@ class ConnectionControllerTest {
         ),
         Arguments.of(
             HideDiscrepancyDto.builder()
-                .hiddenForDesignatedBodyCode("")
-                .hiddenBy(ADMIN_NAME)
-                .doctors(validDoctors)
-                .build(),
-            "hiddenForDesignatedBodyCode is blank"
-        ),
-        Arguments.of(
-            HideDiscrepancyDto.builder()
-                .hiddenForDesignatedBodyCode(DESIGNATED_BODY_CODES)
+                .adminDesignatedBodyCodes(List.of(DESIGNATED_BODY_CODES))
                 .hiddenBy(ADMIN_NAME)
                 .doctors(null)
                 .build(),
@@ -437,7 +429,7 @@ class ConnectionControllerTest {
         ),
         Arguments.of(
             HideDiscrepancyDto.builder()
-                .hiddenForDesignatedBodyCode(DESIGNATED_BODY_CODES)
+                .adminDesignatedBodyCodes(List.of(DESIGNATED_BODY_CODES))
                 .hiddenBy(ADMIN_NAME)
                 .doctors(List.of())
                 .build(),
@@ -445,7 +437,7 @@ class ConnectionControllerTest {
         ),
         Arguments.of(
             HideDiscrepancyDto.builder()
-                .hiddenForDesignatedBodyCode(DESIGNATED_BODY_CODES)
+                .adminDesignatedBodyCodes(List.of(DESIGNATED_BODY_CODES))
                 .hiddenBy(null)
                 .doctors(validDoctors)
                 .build(),
@@ -453,7 +445,7 @@ class ConnectionControllerTest {
         ),
         Arguments.of(
             HideDiscrepancyDto.builder()
-                .hiddenForDesignatedBodyCode(DESIGNATED_BODY_CODES)
+                .adminDesignatedBodyCodes(List.of(DESIGNATED_BODY_CODES))
                 .hiddenBy(" ")
                 .doctors(validDoctors)
                 .build(),
@@ -466,14 +458,20 @@ class ConnectionControllerTest {
   void shouldHideDiscrepancies() throws Exception {
     // given
     DoctorInfoDto doctor = DoctorInfoDto.builder().gmcId(gmcId)
-        .currentDesignatedBodyCode(designatedBodyCode).build();
+        .currentDesignatedBodyCode(designatedBody1)
+        .programmeOwnerDesignatedBodyCode(designatedBody2).build();
+
     final var hideDiscrepancyDto = HideDiscrepancyDto.builder()
-        .hiddenForDesignatedBodyCode(DESIGNATED_BODY_CODES)
+        .adminDesignatedBodyCodes(List.of(DESIGNATED_BODY_CODES))
         .doctors(List.of(doctor)).hiddenBy(ADMIN_NAME).build();
 
+    var item = HideDiscrepancyResponseDto.HideDiscrepancyResponseItem.builder()
+        .gmcId(gmcId)
+        .successfulDbcCodes(List.of(designatedBodyCode))
+        .build();
+
     final var response = HideDiscrepancyResponseDto.builder()
-        .hiddenForDesignatedBodyCode(designatedBodyCode)
-        .successfulHiddenGmcIds(List.of(gmcId))
+        .results(List.of(item))
         .build();
 
     when(hiddenDiscrepancyService.hideDiscrepancies(any(HideDiscrepancyDto.class)))

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/mapper/HiddenDiscrepancyMapperTest.java
@@ -45,14 +45,13 @@ class HiddenDiscrepancyMapperTest {
   void shouldMapAllFieldsAndIgnoreIdWhenToEntityCalled() {
     // given
     HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
-        .hiddenForDesignatedBodyCode(DBC)
         .hiddenBy(HIDDEN_BY)
         .reason(REASON)
         .doctors(List.of()) // doctors list is not mapped, so can be empty
         .build();
 
     // when
-    HiddenDiscrepancy entity = mapper.toEntity(dto, GMC_ID, BATCH_TIME);
+    HiddenDiscrepancy entity = mapper.toEntity(dto, GMC_ID, BATCH_TIME, DBC);
 
     // then
     assertThat(entity).isNotNull();
@@ -62,8 +61,7 @@ class HiddenDiscrepancyMapperTest {
 
     // mapped fields
     assertThat(entity.getGmcId()).isEqualTo(GMC_ID);
-    assertThat(entity.getHiddenForDesignatedBodyCode()).isEqualTo(
-        dto.getHiddenForDesignatedBodyCode());
+    assertThat(entity.getHiddenForDesignatedBodyCode()).isEqualTo(DBC);
     assertThat(entity.getHiddenBy()).isEqualTo(dto.getHiddenBy());
     assertThat(entity.getReason()).isEqualTo(dto.getReason());
     assertThat(entity.getHiddenDateTime()).isEqualTo(BATCH_TIME);

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
@@ -130,8 +130,10 @@ class HiddenDiscrepancyServiceTest {
 
     HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
 
-    assertResponseListCounts(response, 0, 0, 0);
-    assertResponseLists(response, List.of(), List.of(), List.of());
+    // expect no results for invalid doctors
+    assertNotNull(response);
+    assertNotNull(response.getResults());
+    assertEquals(0, response.getResults().size());
 
     verifyNoInteractions(hiddenDiscrepancyRepository);
     verifyNoInteractions(hiddenDiscrepancyMapper);
@@ -149,7 +151,10 @@ class HiddenDiscrepancyServiceTest {
 
     HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
 
-    assertResponseLists(response, List.of(), List.of(), List.of());
+    // expect no results when admin dbcs invalid
+    assertNotNull(response);
+    assertNotNull(response.getResults());
+    assertEquals(0, response.getResults().size());
 
     verifyNoInteractions(hiddenDiscrepancyRepository);
     verifyNoInteractions(hiddenDiscrepancyMapper);
@@ -159,8 +164,10 @@ class HiddenDiscrepancyServiceTest {
   void shouldReturnEmptyResponseWhenDtoInvalid() {
     HideDiscrepancyResponseDto response = service.hideDiscrepancies(null);
 
-    assertResponseListCounts(response, 0, 0, 0);
-    assertResponseLists(response, List.of(), List.of(), List.of());
+    // expect empty response when dto is null
+    assertNotNull(response);
+    assertNotNull(response.getResults());
+    assertEquals(0, response.getResults().size());
 
     verifyNoInteractions(hiddenDiscrepancyRepository);
     verifyNoInteractions(hiddenDiscrepancyMapper);
@@ -181,8 +188,28 @@ class HiddenDiscrepancyServiceTest {
 
     HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
 
-    assertResponseListCounts(response, 2, 0, 0);
-    assertResponseLists(response, List.of(), List.of(), List.of(GMC_ID_1, GMC_ID_2));
+    assertNotNull(response);
+    var resultMap2 = response.getResults().stream()
+        .collect(Collectors.toMap(r -> r.getGmcId(), r -> r));
+
+    var item1 = resultMap2.get(GMC_ID_1);
+    var item2 = resultMap2.get(GMC_ID_2);
+
+    assertNotNull(item1);
+    assertListContainsExactlyIgnoringOrder(item1.getExistingDbcCodes(), List.of(ADMIN_DBC_1));
+    assertListContainsExactlyIgnoringOrder(
+        item1.getSuccessfulDbcCodes() == null ? List.of() : item1.getSuccessfulDbcCodes(),
+        List.of());
+    assertListContainsExactlyIgnoringOrder(
+        item1.getFailedDbcCodes() == null ? List.of() : item1.getFailedDbcCodes(), List.of());
+
+    assertNotNull(item2);
+    assertListContainsExactlyIgnoringOrder(item2.getExistingDbcCodes(), List.of(ADMIN_DBC_1));
+    assertListContainsExactlyIgnoringOrder(
+        item2.getSuccessfulDbcCodes() == null ? List.of() : item2.getSuccessfulDbcCodes(),
+        List.of());
+    assertListContainsExactlyIgnoringOrder(
+        item2.getFailedDbcCodes() == null ? List.of() : item2.getFailedDbcCodes(), List.of());
 
     verify(hiddenDiscrepancyRepository, never()).saveAll(anyList());
     verifyNoInteractions(hiddenDiscrepancyMapper);
@@ -208,8 +235,22 @@ class HiddenDiscrepancyServiceTest {
 
     HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
 
-    assertResponseListCounts(response, 1, 2, 0);
-    assertResponseLists(response, List.of(GMC_ID_2, GMC_ID_3), List.of(), List.of(GMC_ID_1));
+    assertNotNull(response);
+    var resultMap3 = response.getResults().stream()
+        .collect(Collectors.toMap(r -> r.getGmcId(), r -> r));
+
+    // GMC1 existing
+    var it1 = resultMap3.get(GMC_ID_1);
+    assertNotNull(it1);
+    assertListContainsExactlyIgnoringOrder(it1.getExistingDbcCodes(), List.of(ADMIN_DBC_1));
+
+    // GMC2 and GMC3 successful
+    var it2 = resultMap3.get(GMC_ID_2);
+    var it3 = resultMap3.get(GMC_ID_3);
+    assertNotNull(it2);
+    assertNotNull(it3);
+    assertListContainsExactlyIgnoringOrder(it2.getSuccessfulDbcCodes(), List.of(ADMIN_DBC_1));
+    assertListContainsExactlyIgnoringOrder(it3.getSuccessfulDbcCodes(), List.of(ADMIN_DBC_1));
 
     verify(hiddenDiscrepancyRepository).saveAll(saveCaptor.capture());
     List<HiddenDiscrepancy> saved = saveCaptor.getValue();
@@ -244,9 +285,19 @@ class HiddenDiscrepancyServiceTest {
 
     HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
 
-    assertResponseListCounts(response, 0, 2, 1);
-    assertResponseLists(response, List.of(GMC_ID_1, GMC_ID_2), List.of(GMC_ID_3), List.of()
-    );
+    assertNotNull(response);
+    var resultMap4 = response.getResults().stream()
+        .collect(Collectors.toMap(r -> r.getGmcId(), r -> r));
+
+    var a1 = resultMap4.get(GMC_ID_1);
+    var a2 = resultMap4.get(GMC_ID_2);
+    var a3 = resultMap4.get(GMC_ID_3);
+    assertNotNull(a1);
+    assertNotNull(a2);
+    assertNotNull(a3);
+    assertListContainsExactlyIgnoringOrder(a1.getSuccessfulDbcCodes(), List.of(ADMIN_DBC_1));
+    assertListContainsExactlyIgnoringOrder(a2.getSuccessfulDbcCodes(), List.of(ADMIN_DBC_1));
+    assertListContainsExactlyIgnoringOrder(a3.getFailedDbcCodes(), List.of(ADMIN_DBC_1));
   }
 
   @Test
@@ -270,8 +321,19 @@ class HiddenDiscrepancyServiceTest {
 
     HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
 
-    assertResponseListCounts(response, 0, 2, 0);
-    assertResponseLists(response, List.of(GMC_ID_1, GMC_ID_2), List.of(), List.of());
+    assertNotNull(response);
+    var resultMap5 = response.getResults().stream()
+        .collect(Collectors.toMap(r -> r.getGmcId(), r -> r));
+    var b1 = resultMap5.get(GMC_ID_1);
+    var b2 = resultMap5.get(GMC_ID_2);
+    assertNotNull(b1);
+    assertNotNull(b2);
+    assertListContainsExactlyIgnoringOrder(b1.getSuccessfulDbcCodes(), List.of(ADMIN_DBC_1));
+    assertListContainsExactlyIgnoringOrder(b2.getSuccessfulDbcCodes(), List.of(ADMIN_DBC_1));
+    assertListContainsExactlyIgnoringOrder(
+        b1.getFailedDbcCodes() == null ? List.of() : b1.getFailedDbcCodes(), List.of());
+    assertListContainsExactlyIgnoringOrder(
+        b2.getFailedDbcCodes() == null ? List.of() : b2.getFailedDbcCodes(), List.of());
 
     verify(hiddenDiscrepancyRepository)
         .findByGmcIdInAndHiddenForDesignatedBodyCodeIn(gmcIdsCaptor.capture(),
@@ -286,6 +348,67 @@ class HiddenDiscrepancyServiceTest {
         any(LocalDateTime.class), anyString());
     verify(hiddenDiscrepancyMapper, times(1)).toEntity(eq(dto), eq(GMC_ID_2),
         any(LocalDateTime.class), anyString());
+  }
+
+  @Test
+  void shouldHideDiscrepanciesWhenOneDoctorCoversBothDbcsAndAnotherCoversOne() {
+    // admin has two dbcs
+    final HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
+        .adminDesignatedBodyCodes(List.of(ADMIN_DBC_1, ADMIN_DBC_2))
+        .hiddenBy(HIDDEN_BY)
+        .reason(REASON)
+        // doctor1 covers both dbcs, doctor2 covers only first dbc
+        .doctors(List.of(doc(GMC_ID_1, ADMIN_DBC_1, ADMIN_DBC_2), doc(GMC_ID_2, ADMIN_DBC_1, null)))
+        .build();
+
+    // none exist beforehand
+    when(hiddenDiscrepancyRepository.findByGmcIdInAndHiddenForDesignatedBodyCodeIn(anyList(),
+        anyList()))
+        .thenReturn(List.of());
+
+    // mapper should produce real entities for each toSave
+    mockMapperToReturnRealEntity();
+
+    // make saveAll return the passed list (simulate successful save)
+    when(hiddenDiscrepancyRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+    HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
+
+    // expect two result items (one per doctor)
+    assertNotNull(response);
+    assertNotNull(response.getResults());
+    assertEquals(2, response.getResults().size());
+
+    var resultMap = response.getResults().stream()
+        .collect(Collectors.toMap(r -> r.getGmcId(), r -> r));
+
+    var r1 = resultMap.get(GMC_ID_1);
+    var r2 = resultMap.get(GMC_ID_2);
+
+    // doctor1 should have both successful dbcs
+    assertNotNull(r1);
+    assertListContainsExactlyIgnoringOrder(r1.getSuccessfulDbcCodes(),
+        List.of(ADMIN_DBC_1, ADMIN_DBC_2));
+    assertListContainsExactlyIgnoringOrder(
+        r1.getFailedDbcCodes() == null ? List.of() : r1.getFailedDbcCodes(), List.of());
+    assertListContainsExactlyIgnoringOrder(
+        r1.getExistingDbcCodes() == null ? List.of() : r1.getExistingDbcCodes(), List.of());
+
+    // doctor2 should have only first dbc successful
+    assertNotNull(r2);
+    assertListContainsExactlyIgnoringOrder(r2.getSuccessfulDbcCodes(), List.of(ADMIN_DBC_1));
+    assertListContainsExactlyIgnoringOrder(
+        r2.getFailedDbcCodes() == null ? List.of() : r2.getFailedDbcCodes(), List.of());
+    assertListContainsExactlyIgnoringOrder(
+        r2.getExistingDbcCodes() == null ? List.of() : r2.getExistingDbcCodes(), List.of());
+
+    // verify mapper called 3 times (2 for doctor1, 1 for doctor2)
+    verify(hiddenDiscrepancyMapper, times(1)).toEntity(eq(dto), eq(GMC_ID_1),
+        any(LocalDateTime.class), eq(ADMIN_DBC_1));
+    verify(hiddenDiscrepancyMapper, times(1)).toEntity(eq(dto), eq(GMC_ID_1),
+        any(LocalDateTime.class), eq(ADMIN_DBC_2));
+    verify(hiddenDiscrepancyMapper, times(1)).toEntity(eq(dto), eq(GMC_ID_2),
+        any(LocalDateTime.class), eq(ADMIN_DBC_1));
   }
 
   @Test
@@ -460,74 +583,6 @@ class HiddenDiscrepancyServiceTest {
               .hiddenDateTime(batchTime)
               .build();
         });
-  }
-
-  /**
-   * Assert the counts in the response and that the lists are non-null (but not their contents).
-   *
-   * @param response           the service response containing details of hidden discrepancies
-   * @param expectedExisting   the expected number of existing discrepancies
-   * @param expectedSuccessful the expected number of hide discrepancy updates to succeed
-   * @param expectedFailed     the expected number of hide discrepancy updates to succeed
-   */
-  private void assertResponseListCounts(HideDiscrepancyResponseDto response, int expectedExisting,
-      int expectedSuccessful, int expectedFailed) {
-    assertNotNull(response);
-    var results = response.getResults();
-    assertNotNull(results);
-
-    var existing = results.stream()
-        .filter(
-            i -> i.getExistingDbcCodes() != null && i.getExistingDbcCodes().contains(ADMIN_DBC_1))
-        .map(i -> i.getGmcId())
-        .collect(Collectors.toSet());
-    var successful = results.stream()
-        .filter(i -> i.getSuccessfulDbcCodes() != null && i.getSuccessfulDbcCodes()
-            .contains(ADMIN_DBC_1))
-        .map(i -> i.getGmcId())
-        .collect(Collectors.toSet());
-    var failed = results.stream()
-        .filter(i -> i.getFailedDbcCodes() != null && i.getFailedDbcCodes().contains(ADMIN_DBC_1))
-        .map(i -> i.getGmcId())
-        .collect(Collectors.toSet());
-
-    assertEquals(expectedExisting, existing.size());
-    assertEquals(expectedSuccessful, successful.size());
-    assertEquals(expectedFailed, failed.size());
-  }
-
-  /**
-   * Assert the contents of the three lists in the response (ignoring order).
-   *
-   * @param response           the service response containing details of hidden discrepancies
-   * @param expectedExisting   the expected number of existing discrepancies
-   * @param expectedSuccessful the expected number of hide discrepancy updates to succeed
-   * @param expectedFailed     the expected number of hide discrepancy updates to succeed
-   */
-  private void assertResponseLists(HideDiscrepancyResponseDto response,
-      List<String> expectedSuccessful,
-      List<String> expectedFailed,
-      List<String> expectedExisting) {
-
-    var results = response.getResults();
-    var successful = results.stream()
-        .filter(i -> i.getSuccessfulDbcCodes() != null && i.getSuccessfulDbcCodes()
-            .contains(ADMIN_DBC_1))
-        .map(i -> i.getGmcId())
-        .collect(Collectors.toList());
-    var failed = results.stream()
-        .filter(i -> i.getFailedDbcCodes() != null && i.getFailedDbcCodes().contains(ADMIN_DBC_1))
-        .map(i -> i.getGmcId())
-        .collect(Collectors.toList());
-    var existing = results.stream()
-        .filter(
-            i -> i.getExistingDbcCodes() != null && i.getExistingDbcCodes().contains(ADMIN_DBC_1))
-        .map(i -> i.getGmcId())
-        .collect(Collectors.toList());
-
-    assertListContainsExactlyIgnoringOrder(successful, expectedSuccessful);
-    assertListContainsExactlyIgnoringOrder(failed, expectedFailed);
-    assertListContainsExactlyIgnoringOrder(existing, expectedExisting);
   }
 
   private void assertListContainsExactlyIgnoringOrder(List<String> actual, List<String> expected) {

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
@@ -128,17 +128,22 @@ class HiddenDiscrepancyServiceTest {
     );
   }
 
-  private static Stream<List<DoctorInfoDto>> invalidDoctorDtosSupplier() {
+  private static Stream<List<DoctorInfoDto>> invalidDoctorlistSupplier() {
     return Stream.of(
         null,
-        List.of(),
+        List.of()
+    );
+  }
+
+  private static Stream<List<DoctorInfoDto>> invalidDoctorGmcIdsSupplier() {
+    return Stream.of(
         List.of(doc(null)),
-        List.of(doc(null), doc(null))
+        List.of(doc(null), doc(""))
     );
   }
 
   @ParameterizedTest
-  @MethodSource("invalidDoctorDtosSupplier")
+  @MethodSource("invalidDoctorlistSupplier")
   void shouldReturnEmptyResponseWhenDoctorsInvalid(List<DoctorInfoDto> doctors) {
     HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
         .adminDesignatedBodyCodes(List.of(ADMIN_DBC_1, ADMIN_DBC_2))
@@ -147,12 +152,7 @@ class HiddenDiscrepancyServiceTest {
         .doctors(doctors)
         .build();
 
-    HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
-
-    // expect empty response for invalid doctors
-    assertNotNull(response);
-    assertNotNull(response.getResults());
-    assertEquals(0, response.getResults().size());
+    assertThrows(IllegalArgumentException.class, () -> service.hideDiscrepancies(dto));
 
     verifyNoInteractions(hiddenDiscrepancyRepository);
     verifyNoInteractions(hideDiscrepancyMapper);
@@ -168,9 +168,24 @@ class HiddenDiscrepancyServiceTest {
         .doctors(List.of(doc(GMC_ID_1)))
         .build();
 
+    assertThrows(IllegalArgumentException.class, () -> service.hideDiscrepancies(dto));
+
+    verifyNoInteractions(hiddenDiscrepancyRepository);
+    verifyNoInteractions(hideDiscrepancyMapper);
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidDoctorGmcIdsSupplier")
+  void shouldReturnEmptyResponseWhenGmcIdInvalid(List<DoctorInfoDto> doctors) {
+    HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
+        .adminDesignatedBodyCodes(List.of(ADMIN_DBC_1))
+        .hiddenBy(HIDDEN_BY)
+        .reason(REASON)
+        .doctors(doctors)
+        .build();
+
     HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
 
-    // expect empty response for invalid admin dbcs
     assertNotNull(response);
     assertNotNull(response.getResults());
     assertEquals(0, response.getResults().size());
@@ -181,12 +196,7 @@ class HiddenDiscrepancyServiceTest {
 
   @Test
   void shouldReturnEmptyResponseWhenDtoInvalid() {
-    HideDiscrepancyResponseDto response = service.hideDiscrepancies(null);
-
-    // expect empty response when dto is null
-    assertNotNull(response);
-    assertNotNull(response.getResults());
-    assertEquals(0, response.getResults().size());
+    assertThrows(NullPointerException.class, () -> service.hideDiscrepancies(null));
 
     verifyNoInteractions(hiddenDiscrepancyRepository);
     verifyNoInteractions(hideDiscrepancyMapper);

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
@@ -130,7 +130,7 @@ class HiddenDiscrepancyServiceTest {
 
     HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
 
-    // expect no results for invalid doctors
+    // expect empty response for invalid doctors
     assertNotNull(response);
     assertNotNull(response.getResults());
     assertEquals(0, response.getResults().size());
@@ -151,7 +151,7 @@ class HiddenDiscrepancyServiceTest {
 
     HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
 
-    // expect no results when admin dbcs invalid
+    // expect empty response for invalid admin dbcs
     assertNotNull(response);
     assertNotNull(response.getResults());
     assertEquals(0, response.getResults().size());
@@ -279,7 +279,7 @@ class HiddenDiscrepancyServiceTest {
         .findByGmcIdInAndHiddenForDesignatedBodyCodeIn(anyList(), anyList()))
         .thenReturn(List.of());
     when(hiddenDiscrepancyRepository.saveAll(anyList()))
-        .thenReturn(List.of(entity(GMC_ID_1), entity(GMC_ID_2))); // nowHidden missing GMC3
+        .thenReturn(List.of(entity(GMC_ID_1), entity(GMC_ID_2)));
 
     mockMapperToReturnRealEntity();
 

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
@@ -193,8 +193,6 @@ class HiddenDiscrepancyServiceTest {
         .collect(Collectors.toMap(r -> r.getGmcId(), r -> r));
 
     var item1 = resultMap2.get(GMC_ID_1);
-    var item2 = resultMap2.get(GMC_ID_2);
-
     assertNotNull(item1);
     assertListContainsExactlyIgnoringOrder(item1.getExistingDbcCodes(), List.of(ADMIN_DBC_1));
     assertListContainsExactlyIgnoringOrder(
@@ -203,6 +201,7 @@ class HiddenDiscrepancyServiceTest {
     assertListContainsExactlyIgnoringOrder(
         item1.getFailedDbcCodes() == null ? List.of() : item1.getFailedDbcCodes(), List.of());
 
+    var item2 = resultMap2.get(GMC_ID_2);
     assertNotNull(item2);
     assertListContainsExactlyIgnoringOrder(item2.getExistingDbcCodes(), List.of(ADMIN_DBC_1));
     assertListContainsExactlyIgnoringOrder(
@@ -383,8 +382,6 @@ class HiddenDiscrepancyServiceTest {
         .collect(Collectors.toMap(r -> r.getGmcId(), r -> r));
 
     var r1 = resultMap.get(GMC_ID_1);
-    var r2 = resultMap.get(GMC_ID_2);
-
     // doctor1 should have both successful dbcs
     assertNotNull(r1);
     assertListContainsExactlyIgnoringOrder(r1.getSuccessfulDbcCodes(),
@@ -394,6 +391,7 @@ class HiddenDiscrepancyServiceTest {
     assertListContainsExactlyIgnoringOrder(
         r1.getExistingDbcCodes() == null ? List.of() : r1.getExistingDbcCodes(), List.of());
 
+    var r2 = resultMap.get(GMC_ID_2);
     // doctor2 should have only first dbc successful
     assertNotNull(r2);
     assertListContainsExactlyIgnoringOrder(r2.getSuccessfulDbcCodes(), List.of(ADMIN_DBC_1));
@@ -554,6 +552,7 @@ class HiddenDiscrepancyServiceTest {
     when(d.getProgrammeOwnerDesignatedBodyCode()).thenReturn(programmeDbc);
     return d;
   }
+
   /**
    * Simple entity builder for repository return values (only gmcId is relevant for service logic).
    *

--- a/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/connection/service/HiddenDiscrepancyServiceTest.java
@@ -29,6 +29,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -68,7 +69,8 @@ import uk.nhs.hee.tis.revalidation.connection.repository.HiddenDiscrepancyReposi
 @ExtendWith(MockitoExtension.class)
 class HiddenDiscrepancyServiceTest {
 
-  private static final String DBC = "1-ABCDE";
+  private static final String ADMIN_DBC_1 = "1-ABCDE";
+  private static final String ADMIN_DBC_2 = "1-EDCBA";
   private static final String HIDDEN_BY = "admin";
   private static final String REASON = "reason";
   private static final String EXCHANGE = "exchange";
@@ -100,11 +102,27 @@ class HiddenDiscrepancyServiceTest {
     setField(service, "esSyncDataRoutingKey", ES_SYNC_DATA_ROUTING_KEY);
   }
 
+  private static Stream<List<String>> invalidAdminDbcsSupplier() {
+    return Stream.of(
+        null,
+        List.of()
+    );
+  }
+
+  private static Stream<List<DoctorInfoDto>> invalidDoctorDtosSupplier() {
+    return Stream.of(
+        null,
+        List.of(),
+        List.of(doc(null)),
+        List.of(doc(null), doc(null))
+    );
+  }
+
   @ParameterizedTest
   @MethodSource("invalidDoctorDtosSupplier")
   void shouldReturnEmptyResponseWhenDoctorsInvalid(List<DoctorInfoDto> doctors) {
     HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
-        .hiddenForDesignatedBodyCode(DBC)
+        .adminDesignatedBodyCodes(List.of(ADMIN_DBC_1, ADMIN_DBC_2))
         .hiddenBy(HIDDEN_BY)
         .reason(REASON)
         .doctors(doctors)
@@ -119,29 +137,47 @@ class HiddenDiscrepancyServiceTest {
     verifyNoInteractions(hiddenDiscrepancyMapper);
   }
 
-  private static Stream<List<DoctorInfoDto>> invalidDoctorDtosSupplier() {
-    return Stream.of(
-        null,
-        List.of(),
-        List.of(doc(null)),
-        List.of(doc(null), doc(null))
-    );
+  @ParameterizedTest
+  @MethodSource("invalidAdminDbcsSupplier")
+  void shouldReturnEmptyResponseWhenAdminDbcInvalid(List<String> adminDbcs) {
+    HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
+        .adminDesignatedBodyCodes(adminDbcs)
+        .hiddenBy(HIDDEN_BY)
+        .reason(REASON)
+        .doctors(List.of(doc(GMC_ID_1)))
+        .build();
+
+    HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
+
+    assertResponseLists(response, List.of(), List.of(), List.of());
+
+    verifyNoInteractions(hiddenDiscrepancyRepository);
+    verifyNoInteractions(hiddenDiscrepancyMapper);
   }
 
+  @Test
+  void shouldReturnEmptyResponseWhenDtoInvalid() {
+    HideDiscrepancyResponseDto response = service.hideDiscrepancies(null);
+
+    assertResponseListCounts(response, 0, 0, 0);
+    assertResponseLists(response, List.of(), List.of(), List.of());
+
+    verifyNoInteractions(hiddenDiscrepancyRepository);
+    verifyNoInteractions(hiddenDiscrepancyMapper);
+  }
 
   @Test
   void shouldNotSaveAndShouldReturnExistingHiddenWhenAllRequestedAreAlreadyHidden() {
     HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
-        .hiddenForDesignatedBodyCode(DBC)
+        .adminDesignatedBodyCodes(List.of(ADMIN_DBC_1))
         .hiddenBy(HIDDEN_BY)
         .reason(REASON)
-        .doctors(List.of(doc(GMC_ID_1), doc(GMC_ID_2)))
+        .doctors(List.of(doc(GMC_ID_1, ADMIN_DBC_1, null), doc(GMC_ID_2, ADMIN_DBC_1, null)))
         .build();
 
     when(hiddenDiscrepancyRepository
-        .findByGmcIdInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
-        .thenReturn(List.of(entity(GMC_ID_1), entity(GMC_ID_2))) // alreadyHidden
-        .thenReturn(List.of(entity(GMC_ID_1), entity(GMC_ID_2))); // nowHidden
+        .findByGmcIdInAndHiddenForDesignatedBodyCodeIn(anyList(), anyList()))
+        .thenReturn(List.of(entity(GMC_ID_1), entity(GMC_ID_2)));
 
     HideDiscrepancyResponseDto response = service.hideDiscrepancies(dto);
 
@@ -155,17 +191,18 @@ class HiddenDiscrepancyServiceTest {
   @Test
   void shouldSaveOnlyNewGmcIdsAndReturnSuccessfulAndExistingListsWhenSomeAreNew() {
     final HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
-        .hiddenForDesignatedBodyCode(DBC)
+        .adminDesignatedBodyCodes(List.of(ADMIN_DBC_1))
         .hiddenBy(HIDDEN_BY)
         .reason(REASON)
-        .doctors(List.of(doc(GMC_ID_1), doc(GMC_ID_2), doc(GMC_ID_3)))
+        .doctors(List.of(doc(GMC_ID_1, ADMIN_DBC_1, null), doc(GMC_ID_2, ADMIN_DBC_1, null),
+            doc(GMC_ID_3, ADMIN_DBC_1, null)))
         .build();
 
     when(hiddenDiscrepancyRepository
-        .findByGmcIdInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
+        .findByGmcIdInAndHiddenForDesignatedBodyCodeIn(anyList(), anyList()))
         .thenReturn(List.of(entity(GMC_ID_1)));
     when(hiddenDiscrepancyRepository.saveAll(anyList()))
-        .thenReturn(List.of(entity(GMC_ID_2), entity(GMC_ID_3))); // nowHidden
+        .thenReturn(List.of(entity(GMC_ID_2), entity(GMC_ID_3)));
 
     mockMapperToReturnRealEntity();
 
@@ -180,22 +217,25 @@ class HiddenDiscrepancyServiceTest {
 
     // mapper should be called only for new ids
     verify(hiddenDiscrepancyMapper, never()).toEntity(eq(dto), eq(GMC_ID_1),
-        any(LocalDateTime.class));
-    verify(hiddenDiscrepancyMapper).toEntity(eq(dto), eq(GMC_ID_2), any(LocalDateTime.class));
-    verify(hiddenDiscrepancyMapper).toEntity(eq(dto), eq(GMC_ID_3), any(LocalDateTime.class));
+        any(LocalDateTime.class), anyString());
+    verify(hiddenDiscrepancyMapper).toEntity(eq(dto), eq(GMC_ID_2), any(LocalDateTime.class),
+        anyString());
+    verify(hiddenDiscrepancyMapper).toEntity(eq(dto), eq(GMC_ID_3), any(LocalDateTime.class),
+        anyString());
   }
 
   @Test
   void shouldReturnFailedListWhenDbDoesNotReturnAllAsHiddenAfterSaveAttempt() {
     final HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
-        .hiddenForDesignatedBodyCode(DBC)
+        .adminDesignatedBodyCodes(List.of(ADMIN_DBC_1))
         .hiddenBy(HIDDEN_BY)
         .reason(REASON)
-        .doctors(List.of(doc(GMC_ID_1), doc(GMC_ID_2), doc(GMC_ID_3)))
+        .doctors(List.of(doc(GMC_ID_1, ADMIN_DBC_1, null), doc(GMC_ID_2, ADMIN_DBC_1, null),
+            doc(GMC_ID_3, ADMIN_DBC_1, null)))
         .build();
 
     when(hiddenDiscrepancyRepository
-        .findByGmcIdInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
+        .findByGmcIdInAndHiddenForDesignatedBodyCodeIn(anyList(), anyList()))
         .thenReturn(List.of());
     when(hiddenDiscrepancyRepository.saveAll(anyList()))
         .thenReturn(List.of(entity(GMC_ID_1), entity(GMC_ID_2))); // nowHidden missing GMC3
@@ -210,17 +250,17 @@ class HiddenDiscrepancyServiceTest {
   }
 
   @Test
-  void shouldDedupRequestedGmcIdsAndReturnListsWithoutDuplicatesWhenInputContainsDuplicates() {
+  void shouldRespondWithoutDuplicatesWhenInputContainsDuplicates() {
     final HideDiscrepancyDto dto = HideDiscrepancyDto.builder()
-        .hiddenForDesignatedBodyCode(DBC)
+        .adminDesignatedBodyCodes(List.of(ADMIN_DBC_1))
         .hiddenBy(HIDDEN_BY)
         .reason(REASON)
-        .doctors(List.of(doc(GMC_ID_1), doc(GMC_ID_1), doc(GMC_ID_2)))
+        .doctors(List.of(doc(GMC_ID_1, ADMIN_DBC_1, null), doc(GMC_ID_1, ADMIN_DBC_1, null),
+            doc(GMC_ID_2, ADMIN_DBC_1, null)))
         .build();
 
-    // capture the gmcIds list passed into repository (to ensure distinct() is applied)
     when(hiddenDiscrepancyRepository
-        .findByGmcIdInAndHiddenForDesignatedBodyCode(anyList(), eq(DBC)))
+        .findByGmcIdInAndHiddenForDesignatedBodyCodeIn(anyList(), anyList()))
         .thenReturn(List.of());
 
     when(hiddenDiscrepancyRepository.saveAll(anyList()))
@@ -234,7 +274,8 @@ class HiddenDiscrepancyServiceTest {
     assertResponseLists(response, List.of(GMC_ID_1, GMC_ID_2), List.of(), List.of());
 
     verify(hiddenDiscrepancyRepository)
-        .findByGmcIdInAndHiddenForDesignatedBodyCode(gmcIdsCaptor.capture(), eq(DBC));
+        .findByGmcIdInAndHiddenForDesignatedBodyCodeIn(gmcIdsCaptor.capture(),
+            eq(List.of(ADMIN_DBC_1)));
     List<String> requestedGmcsAtFirstQuery = gmcIdsCaptor.getValue();
     assertListContainsExactlyIgnoringOrder(requestedGmcsAtFirstQuery, List.of(GMC_ID_1, GMC_ID_2));
 
@@ -242,16 +283,16 @@ class HiddenDiscrepancyServiceTest {
     assertSavedEntities(saveCaptor.getValue(), Set.of(GMC_ID_1, GMC_ID_2), dto);
 
     verify(hiddenDiscrepancyMapper, times(1)).toEntity(eq(dto), eq(GMC_ID_1),
-        any(LocalDateTime.class));
+        any(LocalDateTime.class), anyString());
     verify(hiddenDiscrepancyMapper, times(1)).toEntity(eq(dto), eq(GMC_ID_2),
-        any(LocalDateTime.class));
+        any(LocalDateTime.class), anyString());
   }
 
   @Test
   void shouldSendHiddenDiscrepanciesForSync() {
     final HiddenDiscrepancy hiddenDiscrepancy = HiddenDiscrepancy.builder()
         .gmcId(GMC_ID_1)
-        .hiddenForDesignatedBodyCode(DBC)
+        .hiddenForDesignatedBodyCode(ADMIN_DBC_1)
         .hiddenBy(HIDDEN_BY)
         .reason(REASON)
         .build();
@@ -280,13 +321,13 @@ class HiddenDiscrepancyServiceTest {
   void shouldPaginateHiddenDiscrepanciesForSync() {
     HiddenDiscrepancy hd1 = HiddenDiscrepancy.builder()
         .gmcId(GMC_ID_1)
-        .hiddenForDesignatedBodyCode(DBC)
+        .hiddenForDesignatedBodyCode(ADMIN_DBC_1)
         .hiddenBy(HIDDEN_BY)
         .reason(REASON)
         .build();
     HiddenDiscrepancy hd2 = HiddenDiscrepancy.builder()
         .gmcId(GMC_ID_2)
-        .hiddenForDesignatedBodyCode(DBC)
+        .hiddenForDesignatedBodyCode(ADMIN_DBC_1)
         .hiddenBy(HIDDEN_BY)
         .reason(REASON)
         .build();
@@ -347,7 +388,7 @@ class HiddenDiscrepancyServiceTest {
     HiddenDiscrepancy entity = HiddenDiscrepancy.builder()
         .id(hiddenDiscrepancyId)
         .gmcId(GMC_ID_1)
-        .hiddenForDesignatedBodyCode(DBC)
+        .hiddenForDesignatedBodyCode(ADMIN_DBC_1)
         .build();
     when(hiddenDiscrepancyRepository.findById(hiddenDiscrepancyId))
         .thenReturn(Optional.of(entity));
@@ -357,7 +398,7 @@ class HiddenDiscrepancyServiceTest {
     verify(hiddenDiscrepancyRepository).delete(deleteCaptor.capture());
     var result = deleteCaptor.getValue();
     assertThat(result.getGmcId()).isEqualTo(GMC_ID_1);
-    assertThat(result.getHiddenForDesignatedBodyCode()).isEqualTo(DBC);
+    assertThat(result.getHiddenForDesignatedBodyCode()).isEqualTo(ADMIN_DBC_1);
     assertThat(result.getId()).isEqualTo(hiddenDiscrepancyId);
   }
 
@@ -379,10 +420,17 @@ class HiddenDiscrepancyServiceTest {
 
   private static DoctorInfoDto doc(String gmc) {
     DoctorInfoDto d = mock(DoctorInfoDto.class);
-    when(d.getGmcId()).thenReturn(gmc);
+    lenient().when(d.getGmcId()).thenReturn(gmc);
     return d;
   }
 
+  private static DoctorInfoDto doc(String gmc, String currentDbc, String programmeDbc) {
+    DoctorInfoDto d = mock(DoctorInfoDto.class);
+    when(d.getGmcId()).thenReturn(gmc);
+    when(d.getCurrentDesignatedBodyCode()).thenReturn(currentDbc);
+    when(d.getProgrammeOwnerDesignatedBodyCode()).thenReturn(programmeDbc);
+    return d;
+  }
   /**
    * Simple entity builder for repository return values (only gmcId is relevant for service logic).
    *
@@ -390,21 +438,23 @@ class HiddenDiscrepancyServiceTest {
    * @return The HiddenDiscrepancy
    */
   private HiddenDiscrepancy entity(String gmcId) {
-    return HiddenDiscrepancy.builder().gmcId(gmcId).build();
+    return HiddenDiscrepancy.builder().gmcId(gmcId).hiddenForDesignatedBodyCode(ADMIN_DBC_1)
+        .build();
   }
 
-  // Mock mapper to return a real entity based on the input dto and gmcId
+  // Mock mapper to return a real entity based on the input dto, gmcId and supplied dbc
   private void mockMapperToReturnRealEntity() {
     when(hiddenDiscrepancyMapper.toEntity(any(HideDiscrepancyDto.class), anyString(),
-        any(LocalDateTime.class)))
+        any(LocalDateTime.class), anyString()))
         .thenAnswer(inv -> {
           HideDiscrepancyDto dto = inv.getArgument(0, HideDiscrepancyDto.class);
           String gmcId = inv.getArgument(1, String.class);
           LocalDateTime batchTime = inv.getArgument(2, LocalDateTime.class);
+          String dbc = inv.getArgument(3, String.class);
 
           return HiddenDiscrepancy.builder()
               .gmcId(gmcId)
-              .hiddenForDesignatedBodyCode(dto.getHiddenForDesignatedBodyCode())
+              .hiddenForDesignatedBodyCode(dbc)
               .hiddenBy(dto.getHiddenBy())
               .reason(dto.getReason())
               .hiddenDateTime(batchTime)
@@ -423,15 +473,27 @@ class HiddenDiscrepancyServiceTest {
   private void assertResponseListCounts(HideDiscrepancyResponseDto response, int expectedExisting,
       int expectedSuccessful, int expectedFailed) {
     assertNotNull(response);
-    assertNotNull(response.getSuccessfulHiddenGmcIds());
-    assertNotNull(response.getFailedToHideGmcIds());
-    assertNotNull(response.getExistingHiddenGmcIds());
-    assertEquals(HiddenDiscrepancyServiceTest.DBC, response.getHiddenForDesignatedBodyCode());
+    var results = response.getResults();
+    assertNotNull(results);
 
-    assertEquals(expectedExisting, response.getExistingHiddenGmcIds().size());
-    assertEquals(expectedSuccessful, response.getSuccessfulHiddenGmcIds().size());
-    assertEquals(expectedFailed, response.getFailedToHideGmcIds().size());
+    var existing = results.stream()
+        .filter(
+            i -> i.getExistingDbcCodes() != null && i.getExistingDbcCodes().contains(ADMIN_DBC_1))
+        .map(i -> i.getGmcId())
+        .collect(Collectors.toSet());
+    var successful = results.stream()
+        .filter(i -> i.getSuccessfulDbcCodes() != null && i.getSuccessfulDbcCodes()
+            .contains(ADMIN_DBC_1))
+        .map(i -> i.getGmcId())
+        .collect(Collectors.toSet());
+    var failed = results.stream()
+        .filter(i -> i.getFailedDbcCodes() != null && i.getFailedDbcCodes().contains(ADMIN_DBC_1))
+        .map(i -> i.getGmcId())
+        .collect(Collectors.toSet());
 
+    assertEquals(expectedExisting, existing.size());
+    assertEquals(expectedSuccessful, successful.size());
+    assertEquals(expectedFailed, failed.size());
   }
 
   /**
@@ -447,10 +509,25 @@ class HiddenDiscrepancyServiceTest {
       List<String> expectedFailed,
       List<String> expectedExisting) {
 
-    assertListContainsExactlyIgnoringOrder(response.getSuccessfulHiddenGmcIds(),
-        expectedSuccessful);
-    assertListContainsExactlyIgnoringOrder(response.getFailedToHideGmcIds(), expectedFailed);
-    assertListContainsExactlyIgnoringOrder(response.getExistingHiddenGmcIds(), expectedExisting);
+    var results = response.getResults();
+    var successful = results.stream()
+        .filter(i -> i.getSuccessfulDbcCodes() != null && i.getSuccessfulDbcCodes()
+            .contains(ADMIN_DBC_1))
+        .map(i -> i.getGmcId())
+        .collect(Collectors.toList());
+    var failed = results.stream()
+        .filter(i -> i.getFailedDbcCodes() != null && i.getFailedDbcCodes().contains(ADMIN_DBC_1))
+        .map(i -> i.getGmcId())
+        .collect(Collectors.toList());
+    var existing = results.stream()
+        .filter(
+            i -> i.getExistingDbcCodes() != null && i.getExistingDbcCodes().contains(ADMIN_DBC_1))
+        .map(i -> i.getGmcId())
+        .collect(Collectors.toList());
+
+    assertListContainsExactlyIgnoringOrder(successful, expectedSuccessful);
+    assertListContainsExactlyIgnoringOrder(failed, expectedFailed);
+    assertListContainsExactlyIgnoringOrder(existing, expectedExisting);
   }
 
   private void assertListContainsExactlyIgnoringOrder(List<String> actual, List<String> expected) {
@@ -479,7 +556,7 @@ class HiddenDiscrepancyServiceTest {
     assertEquals(expectedGmcs, savedGmcs);
 
     for (HiddenDiscrepancy hd : saved) {
-      assertEquals(dto.getHiddenForDesignatedBodyCode(), hd.getHiddenForDesignatedBodyCode());
+      assertEquals(dto.getAdminDesignatedBodyCodes().get(0), hd.getHiddenForDesignatedBodyCode());
       assertEquals(dto.getHiddenBy(), hd.getHiddenBy());
       assertEquals(dto.getReason(), hd.getReason());
       assertNotNull(hd.getHiddenDateTime());


### PR DESCRIPTION
1) accecpt multiple admin dbcs and calculate the intersection of admin dbcs & doctor dbcs (current dbc & programme owner dbc)
2) the response will return a list of results which are for each gmcId. Frontend doesn't use the details response, but I think it would be better to return them for possible future extension. 

TIS21-8285